### PR TITLE
feat: add CPU profiling actuator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ RMPOD_PLUGIN=rm_pod
 RDT_PLUGIN=rdt
 CPU_PLUGIN=cpu_scale
 ENERGY_PLUGIN=energy
+PROFILE_PLUGIN=cpu_profile
 GO_CILINT_CHECKERS=errcheck,goimports,gosec,gosimple,govet,ineffassign,nilerr,revive,staticcheck,unused
 DOCKER_IMAGE_VERSION=0.4.0
 
@@ -36,7 +37,10 @@ build-plugin-cpu:
 build-plugin-energy:
 	CGO_ENABLED=0 go build -o bin/plugins/${ENERGY_PLUGIN} plugins/${ENERGY_PLUGIN}/cmd/${ENERGY_PLUGIN}.go
 
-build-plugins: build-plugin-scaleout build-plugin-rmpod build-plugin-rdt build-plugin-cpu build-plugin-energy
+build-plugin-profile:
+	CGO_ENABLED=0 go build -o bin/plugins/${PROFILE_PLUGIN} plugins/${PROFILE_PLUGIN}/cmd/${PROFILE_PLUGIN}.go
+
+build-plugins: build-plugin-scaleout build-plugin-rmpod build-plugin-rdt build-plugin-cpu build-plugin-energy build-plugin-profile
 
 controller-images:
 	docker build -t planner:${DOCKER_IMAGE_VERSION} . --no-cache --pull
@@ -47,6 +51,7 @@ plugin-images:
 	docker build -t rdt:${DOCKER_IMAGE_VERSION} -f plugins/rdt/Dockerfile . --no-cache --pull
 	docker build -t cpuscale:${DOCKER_IMAGE_VERSION} -f plugins/cpu_scale/Dockerfile . --no-cache --pull
 	docker build -t energy:${DOCKER_IMAGE_VERSION} -f plugins/energy/Dockerfile . --no-cache --pull
+	docker build -t cpuprofile:${DOCKER_IMAGE_VERSION} -f plugins/cpu_profile/Dockerfile . --no-cache --pull
 
 all-images: controller-images plugin-images
 
@@ -62,8 +67,7 @@ prepare-build:
 	go mod tidy
 
 utest:
-	# Skipping certain trace tests, as they cannot be run safely on public runners.
-	go test -count=1 -parallel 1 -v -skip 'TestTracesForSanity/rdt_trace|TestPowerForSanity/power_efficiency' ./...
+	go test -count=1 -parallel 1 -v ./...
 
 test:
 	hack/run_test.sh

--- a/artefacts/examples/example_deployment_cpu_profile_actuator.yaml
+++ b/artefacts/examples/example_deployment_cpu_profile_actuator.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: function-deployment
+  labels:
+    app: sample-function
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sample-function
+  template:
+    metadata:
+      labels:
+        app: sample-function
+    spec:
+      containers:
+        - name: sample-function
+          image: testfunction/rust_function:0.1
+          ports:
+            - containerPort: 8080
+          resources:
+          requests:
+            cpu: "1"
+          limit:
+            cpu: "1"  
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - Key: "cpu_profile"
+                Operator: In
+                Value: "1"
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: function-service
+spec:
+  selector:
+    app: sample-function
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8080
+  type: LoadBalancer

--- a/docs/cpu_profiling_actuator_usage.md
+++ b/docs/cpu_profiling_actuator_usage.md
@@ -1,0 +1,24 @@
+# CPU Profiling Actuator Usage
+
+CPU profiling actuator enables allocating CPU resources to workloads based on qualitative aspects that can be either related to hardware (e.g., different CPU SKUs, generations, etc.), allocation strategies (e.g., shared vs pinned CPUs) or other CPU configuation aspects.
+
+## 1. Concept 
+* The nodes in the cluster have different CPU specifications, whether due to hardware variations or configuration differences, called ***CPU profiles***.
+
+* Each node has one CPU profile. Multiple nodes can have the same CPU profile.
+
+* At the Kubernetes level, the nodes are labeled based on their corresponding CPU profile. 
+
+* The current implementation uses the Kubernetes CPU manager, where the actuator applies node affinity rules to select the targeted CPU profile. 
+
+## 2. Configuration   
+This actuator uses standard actuator settings plus an additional cpu_profiles field, which specifies an array of all CPU profiles available in the cluster. Each CPU profile is defined according to the parameters shown in the table below.
+
+| Key | Value | Description |
+|-----|------|-------------|
+| id | \<int> | ids start from 1 and must be sequential (no gaps). CPU profiles with lower ids are more cost-effective.
+|name | \<string> | (optional) Used for profile description purposes only. 
+cpu_manager|0|CPU manager identifier. Currently only supports vanilla Kubernetes CPU manager (value: 0).|
+|affinity | 0 \| 1  | Node affinity mode: 1 (required) for optimal ML accuracy;  0 (preferred) to avoid resource blocking.
+|settings |{\<string>: \<string>} |Key-value pairs representing CPU specifications matching Kubernetes node labels. Each key-value pair must be unique across all CPU profiles to avoid conflicts. |  
+

--- a/pkg/controller/state_helper.go
+++ b/pkg/controller/state_helper.go
@@ -58,6 +58,9 @@ func getPods(clientSet kubernetes.Interface,
 		}
 		// for each container an entry is created in the map; the key holds a container index, resource name and identifier for requests and limits.
 		if len(containerResources) < 1 {
+			if len(annotations) != len(pod.ObjectMeta.Annotations) {
+				annotations = pod.ObjectMeta.Annotations
+			}
 			for i, container := range pod.Spec.Containers {
 				for name, requests := range container.Resources.Requests {
 					containerResources[strings.Join([]string{strconv.Itoa(i), name.String(), "requests"}, resourceDelimiter)] = requests.MilliValue()

--- a/pkg/planner/actuators/profiling/cpu_profile.go
+++ b/pkg/planner/actuators/profiling/cpu_profile.go
@@ -1,0 +1,547 @@
+package profiling
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+
+	"os/exec"
+
+	"github.com/intel/intent-driven-orchestration/pkg/common"
+	"github.com/intel/intent-driven-orchestration/pkg/controller"
+	"github.com/intel/intent-driven-orchestration/pkg/planner"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// actionName represents the name of the action.
+const actionName = "profileCPU"
+
+// groupName represents the name for the scaling related set of actions.
+const groupName = "profiling"
+
+const CPUProfileKey = "cpu_profile"
+
+// General settings
+type CPUManager int
+
+const (
+	Vanilla CPUManager = iota
+	CPUControlPlane
+)
+
+type Affinity int
+
+const (
+	Preferred Affinity = iota
+	Required
+)
+
+type CPUProfile struct {
+	ID         int               `json:"id"`
+	Name       string            `json:"name"`
+	CPUManager CPUManager        `json:"cpu_manager"`
+	Affinity   Affinity          `json:"affinity"`
+	Settings   map[string]string `json:"settings"`
+}
+
+// CPUProfileConfig describes the configuration for this actuator.
+type CPUProfileConfig struct {
+	Interpreter           string       `json:"interpreter"`
+	Analytics             string       `json:"analytics_script"`
+	Prediction            string       `json:"prediction_script"`
+	CPUMax                int64        `json:"cpu_max"`
+	LookBack              int          `json:"look_back"`
+	Endpoint              string       `json:"endpoint"`
+	Port                  int          `json:"port"`
+	PluginManagerEndpoint string       `json:"plugin_manager_endpoint"`
+	PluginManagerPort     int          `json:"plugin_manager_port"`
+	MongoEndpoint         string       `json:"mongo_endpoint"`
+	TelemetryEndpoint     string       `json:"telemetry_endpoint"`
+	CPUProfiles           []CPUProfile `json:"cpu_profiles"`
+}
+
+type IndividualCPUEffect struct {
+	ID      int
+	Latency float64
+	Mean    float64
+	Sdt     float32
+}
+
+type CPUProfileEffect struct {
+	// Never ever think about making these non-public! Needed for marshalling this struct.
+	LookupTable      map[int64][]IndividualCPUEffect
+	TrainingFeatures [1]string
+	TargetFeature    string
+	Image            string
+}
+
+// CPUProfileActuator is an actuator supporting the cpu profiling.
+type CPUProfileActuator struct {
+	cfg    CPUProfileConfig
+	tracer controller.Tracer
+	apps   kubernetes.Interface
+}
+
+func (cp CPUProfileActuator) Name() string {
+	return actionName
+}
+
+func (cp CPUProfileActuator) Group() string {
+	return groupName
+}
+
+// requestBody represents the json send to prediction function.
+type requestBody struct {
+	Name   string `json:"name"`
+	Target string `json:"target"`
+	CPUs       int64  `json:"cpus"`
+	CPUProfile int    `json:"cpu_profile"`
+	Replicas   int    `json:"replicas"`
+	Telemetry  string `json:"telemetry"`
+}
+
+// responseBody represents the json returned by the prediction function.
+type responseBody struct {
+	Val float64 `json:"val"`
+}
+
+// doQuery calls the prediction function.
+func doQuery(body requestBody) float64 {
+	tmp, _ := json.Marshal(body)
+	client := http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	resp, err := client.Post("http://localhost:8000", "application/json", bytes.NewBuffer(tmp))
+	if err != nil {
+		klog.Errorf("Could not reach prediction endpoint: %s.", err)
+		return -1.0
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		klog.Errorf("Error to read the body: %s", err)
+		return -1.0
+	}
+	var res responseBody
+	err = json.Unmarshal(respBody, &res)
+	if err != nil {
+		klog.Errorf("Could not unmarshall response: %s - request: %+v - response: %s", err, body, respBody)
+		return -1.0
+	}
+	return res.Val
+}
+
+// getCPUProfile return the cpu profile associated with the POD.
+func (cp CPUProfileActuator) getCPUProfile(state *common.State) (*CPUProfile, error) {
+
+	CPUProfileIDStr, exists := state.Annotations[CPUProfileKey]
+	if !exists {
+		return nil, fmt.Errorf("CPU profile key %s not found in annotations", CPUProfileKey)
+	}
+	CPUProfileID, err := strconv.Atoi(CPUProfileIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CPU profile ID: %v", err)
+	}
+
+	// match the pod's CPUProfile with details of the CPU profile in the config
+	for _, cpuProfile := range cp.cfg.CPUProfiles {
+		if cpuProfile.ID == CPUProfileID {
+			return &cpuProfile, nil
+		}
+	}
+	return nil, fmt.Errorf("current CPU profile id not found in the actuator's config file")
+}
+
+// setCPUProfile() updates the workload with the new CPUprofile's config.
+func (cp CPUProfileActuator) setCPUProfile(state *common.State, newCPUProfileID int) {
+
+	tmp := strings.Split(state.Intent.TargetKey, "/")
+	namespace := tmp[0]
+
+	// get the cpu profile of the current state
+	currentCPUProfile, err := cp.getCPUProfile(state)
+	if err != nil {
+		klog.Errorf("%v", err)
+		return
+	}
+
+	// if the current cpu profile is the same as the new one, return and do nothing
+	if currentCPUProfile.ID == newCPUProfileID {
+		klog.Warning("new and current CPU profiles are the same -- nothing to be done")
+		return
+	}
+
+	// get the new cpu profile DS object (including settings and properties)
+	// assumption: cpu profiles are ordered in the config file. Their IDs are aligned with the slice index oredring +1 (slice indexing starts at 0, profile IDs start at 1)
+	if newCPUProfileID <= 0 || newCPUProfileID > len(cp.cfg.CPUProfiles) {
+		klog.Errorf("new CPU profile ID %d is out of range", newCPUProfileID)
+		return
+	}
+	newCPUProfile := cp.cfg.CPUProfiles[newCPUProfileID-1]
+	// Setup the new cpu profile
+	if state.Intent.TargetKind == "Deployment" {
+		client := cp.apps.AppsV1().Deployments(namespace)
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			deployment, err := client.Get(context.TODO(), tmp[1], metaV1.GetOptions{})
+			if err != nil {
+				klog.Errorf("failed to get latest version of Deployment: %v", err)
+				return nil
+			}
+			updatedDeployment := deployment.DeepCopy()
+			pod := updatedDeployment.Spec.Template
+
+			// Modify the current pod with the target profile
+			if newCPUProfile.CPUManager == Vanilla {
+				klog.Infof("set new CPU profile: %v", newCPUProfile)
+				err = toVanillaProfile(&pod, newCPUProfile, *currentCPUProfile)
+				if err != nil {
+					klog.Errorf("failed to set the new CPU profile: %v", err)
+					return nil
+				}
+				
+			} else if newCPUProfile.CPUManager == CPUControlPlane {
+				klog.Errorf("CPU Control Plane profiles not yet supported")
+				return nil
+			}
+
+			// set annotations for pods (check if working propoerly in real k8s environment)
+			annotations := pod.Annotations
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations[CPUProfileKey] = strconv.Itoa(newCPUProfileID)
+			pod.Annotations = annotations
+
+
+			updatedDeployment.Spec.Template = pod
+			// Update the deployment
+			_, updateErr := client.Update(context.TODO(), updatedDeployment, metaV1.UpdateOptions{})
+			 if updateErr != nil {
+                klog.Errorf("Deployment update failed: %v", updateErr)
+            } else {
+                klog.Infof("Deployment update successful")
+            }
+			return updateErr
+		})
+		if retryErr != nil {
+			klog.Errorf("update of deployment %s failed: %v", state.Intent.TargetKey, retryErr)
+		}
+
+	} else if state.Intent.TargetKind == "ReplicaSet" {
+		client := cp.apps.AppsV1().ReplicaSets(namespace)
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			replicaSet, err := client.Get(context.TODO(), tmp[1], metaV1.GetOptions{})
+			if err != nil {
+				klog.Errorf("failed to get latest version of ReplicaSet: %v", err)
+				return nil
+			}
+			updatedReplicaSet := replicaSet.DeepCopy()
+			Pod := updatedReplicaSet.Spec.Template
+
+			if newCPUProfile.CPUManager == Vanilla {
+				err = toVanillaProfile(&Pod, newCPUProfile, *currentCPUProfile)
+				if err != nil {
+					klog.Errorf("failed to set the new CPU profile: %v", err)
+					return nil
+				}
+			} else if newCPUProfile.CPUManager == CPUControlPlane {
+				klog.Errorf("CPU Control Plane profiles not yet supported")
+				return nil
+
+			}
+
+			// set annotations
+			annotations := Pod.Annotations
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations[CPUProfileKey] = strconv.Itoa(newCPUProfileID)
+			Pod.Annotations = annotations
+
+			updatedReplicaSet.Spec.Template = Pod
+			// Update the ReplicaSet
+			_, updateErr := client.Update(context.TODO(), updatedReplicaSet, metaV1.UpdateOptions{})
+			return updateErr
+		})
+		if retryErr != nil {
+			klog.Errorf("update of ReplicaSet %s failed: %v", state.Intent.TargetKey, retryErr)
+		}
+	}
+}
+
+func getResourceValues(state *common.State, cpuManager CPUManager) int64 {
+	if cpuManager == Vanilla {
+		return getVanillaResourceValues(state)
+	}
+
+	klog.Error("Cannot get ResourceValues for CPU Control Plane profiles -- feature not yet supported.")
+	return 0
+
+}
+
+// findStates determines all CPU profiles that meet target objectives.
+func (cp CPUProfileActuator) findStates(
+	state *common.State, goal *common.State,
+	profiles map[string]common.Profile) ([]common.State, []float64, []planner.Action) {
+
+	var states []common.State
+	var utilities []float64
+	var actions []planner.Action
+
+	// get current cpu profile
+	currentCPUProfile, err := cp.getCPUProfile(state)
+	if err != nil {
+		//assume the default profile in vanilla cpu manager
+		klog.Warning(err, "\nAssumption: current cpu profile is: the default shared - with vanilla cpu manager (the first one in the config file)")
+		currentCPUProfile = &cp.cfg.CPUProfiles[0] // assumption first cpu profile is the default one
+		if state.Annotations == nil {
+			state.Annotations = make(map[string]string)
+		}
+		state.Annotations[CPUProfileKey] = strconv.Itoa(currentCPUProfile.ID)
+	}
+	// initially consider all profiles as valid
+	validProfiles := make(map[int]map[string]float64)
+	for _, cpuProfile := range cp.cfg.CPUProfiles {
+		//if cpuProfile.ID == currentCPUProfile.ID {
+		//	continue
+		//}
+		validProfiles[cpuProfile.ID] = make(map[string]float64)
+	}
+	// get cpu resources
+	cpus := getResourceValues(state, currentCPUProfile.CPUManager)
+	if cpus <= 0 {
+		klog.Error("Failed to get the cpus value")
+		return nil, nil, nil
+	}
+	if cpus > cp.cfg.CPUMax {
+		klog.Errorf("cpus value %d is higher than the max supported", cpus)
+		return nil, nil, nil
+	}
+
+	replicas := len(state.CurrentPods)
+
+	// loop over objectives
+	klog.Infof("Evaluating objectives: %v", goal.Intent.Objectives)
+	for k, v := range goal.Intent.Objectives {
+		if profiles[k].ProfileType != common.ProfileTypeFromText("latency") {
+			continue
+		}
+
+		//predict value for every profile
+		currentValidProfiles := make(map[int]map[string]float64)
+		for _, cpuProfile := range cp.cfg.CPUProfiles {
+
+			// actually predict.
+			body := requestBody{
+				Name:   state.Intent.Key,
+				Target: k,
+				//	IPCValue:           ipc,
+				//	CPUUsageValue:      CPU_usage,
+				//	CacheValue:         cache,
+				//	ContextSwitchValue: context_switch,
+				CPUs:       cpus,
+				CPUProfile: cpuProfile.ID,
+				Replicas:   replicas,
+				Telemetry:  cp.cfg.TelemetryEndpoint,
+			}
+			//klog.Infof("predict value for request: %v", body)
+			predictedValue := doQuery(body)
+			if predictedValue == -1.0 {
+				// Predict script couldn't figure sth out -> need to skip this option.
+				klog.Warningf("Prediction failed for profile %d, objective %s - excluding from valid profiles", cpuProfile.ID, k)
+				continue
+			}
+			klog.Infof("Predicted value for profile %d, objective %s, target %f: %f\n", cpuProfile.ID, k, v, predictedValue)
+
+			if predictedValue <= v {
+				if _, ok := currentValidProfiles[cpuProfile.ID]; !ok {
+					currentValidProfiles[cpuProfile.ID] = make(map[string]float64)
+				}
+				currentValidProfiles[cpuProfile.ID][k] = predictedValue
+			}
+		}
+
+		// Intersect with the global validProfiles map
+		newValidProfiles := make(map[int]map[string]float64)
+		for cpuProfileID := range validProfiles {
+			if _, ok := currentValidProfiles[cpuProfileID]; ok {
+				 newValidProfiles[cpuProfileID] = validProfiles[cpuProfileID]
+				// populate current objective's value in the valid CPU profile
+				validProfiles[cpuProfileID][k] = currentValidProfiles[cpuProfileID][k]
+			}
+		}
+		validProfiles = newValidProfiles
+		klog.Infof("Valid profiles after objective %s: %+v", k, validProfiles)
+
+		// If no valid profiles remain, exit early
+		if len(validProfiles) == 0 {
+			klog.Warningf("No CPU profiles satisfy all objectives for %s", state.Intent.TargetKey)
+			return nil, nil, nil
+		}
+	}
+
+	// create new states for valid profiles
+	for cpuProfileID := range validProfiles {
+		newState := state.DeepCopy()
+		// Assign objectives values from validProfiles[cpuProfileID] to newState.Intent.Objectives
+		for objKey, objValue := range validProfiles[cpuProfileID] {
+			newState.Intent.Objectives[objKey] = objValue
+		}
+
+		if newState.IsBetter(goal, profiles) {
+			newState.Annotations[CPUProfileKey] = strconv.Itoa(cpuProfileID)
+			newState.CurrentData[cp.Name()] = map[string]float64{cp.Name(): 1}
+
+			// TODO: write a better utility function
+			utility := (1.0 / (10 - float64(cpuProfileID))) * (1.0 / goal.Intent.Priority)
+			states = append(states, newState)
+			utilities = append(utilities, utility)
+			actions = append(actions, planner.Action{
+				Name:       cp.Name(),
+				Properties: map[string]string{"id": strconv.Itoa(cpuProfileID)},
+			})
+
+		}
+
+	}
+	klog.Infof("returned actions: %+v", actions)
+	return states, utilities, actions
+}
+
+func (cp CPUProfileActuator) NextState(state *common.State, goal *common.State,
+	profiles map[string]common.Profile) ([]common.State, []float64, []planner.Action) {
+	// we don't need to try this multiple times in a single planning cycle.
+	if _, ok := state.CurrentData[cp.Name()]; ok {
+		return nil, nil, nil
+	}
+	// we don't need to do anything if there are no PODs.
+	if len(state.CurrentPods) == 0 {
+		return nil, nil, nil
+	}
+	// check pods QoS class
+	for _, podState := range state.CurrentPods {
+		if podState.QoSClass != "Guaranteed" {
+			klog.Warningf("Targeted workload is not in guaranteed QoS class.")
+			return nil, nil, nil
+		}
+		break
+	}
+	states, utilities, plan := cp.findStates(state, goal, profiles)
+
+	return states, utilities, plan
+}
+
+func (cp CPUProfileActuator) Perform(state *common.State, plan []planner.Action) {
+
+	klog.Infof("Perform action: %v", plan)
+	for _, item := range plan {
+		if item.Name == actionName {
+			a := item.Properties.(map[string]string)
+			 if cpuProfileStr, ok := a["id"]; ok {
+                cpuProfile, err := strconv.Atoi(cpuProfileStr)
+                if err != nil {
+                    klog.Errorf("Invalid CPU profile ID: %v", err)
+                    continue
+                }
+				cp.setCPUProfile(state, cpuProfile)
+			}
+			break
+		}
+	}
+}
+
+func (cp CPUProfileActuator) Effect(state *common.State, profiles map[string]common.Profile) {
+	if cp.cfg.Analytics == "None" {
+		klog.V(2).Infof("Effect calculation is disabled - will not run analytics.")
+		return
+	}
+
+	var latencyObjectives []string
+	for k := range state.Intent.Objectives {
+		if profiles[k].ProfileType == common.ProfileTypeFromText("latency") {
+			latencyObjectives = append(latencyObjectives, k)
+		}
+	}
+
+	// for all latency related objectives we (re-)analyse what the effect of cpu profiling is.
+	for _, objective := range latencyObjectives {
+
+		cmd := exec.Command(cp.cfg.Interpreter, "-u",
+			cp.cfg.Analytics, state.Intent.Key, objective, "--cpu_profiles", strconv.Itoa(len(cp.cfg.CPUProfiles)))
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			klog.Errorf("Error triggering analytics script: %s - %s.", err, string(out))
+		}
+		klog.V(2).Infof("Script output was: %v", string(out))
+	}
+}
+
+// NewCPUProfileActuator initializes a new actuator.
+func NewCPUProfileActuator(apps kubernetes.Interface, tracer controller.Tracer, cfg CPUProfileConfig) *CPUProfileActuator {
+	cmd := exec.Command(cfg.Interpreter, "-u", cfg.Prediction) 
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		klog.Errorf("Could not get stdout pipe for prediction script: %v", err)
+	}
+	stderrPipe, err2 := cmd.StderrPipe()
+	if err2 != nil {
+		klog.Errorf("Could not get stderr pipe for prediction script: %v", err2)
+	}
+	err = cmd.Start()
+	if err == nil {
+		// Stream stdout
+		go func() {
+			buf := make([]byte, 1024)
+			for {
+				n, rerr := stdoutPipe.Read(buf)
+				if n > 0 {
+					klog.Infof("Prediction stdout: %s", strings.TrimSpace(string(buf[:n])))
+				}
+				if rerr != nil {
+					if rerr != io.EOF {
+						klog.Errorf("Error reading prediction stdout: %v", rerr)
+					}
+					break
+				}
+			}
+		}()
+
+		// Stream stderr
+		go func() {
+			buf := make([]byte, 1024)
+			for {
+				n, rerr := stderrPipe.Read(buf)
+				if n > 0 {
+					klog.Errorf("Prediction stderr: %s", strings.TrimSpace(string(buf[:n])))
+				}
+				if rerr != nil {
+					if rerr != io.EOF {
+						klog.Errorf("Error reading prediction stderr: %v", rerr)
+					}
+					break
+				}
+			}
+		}()
+	}
+	if err != nil {
+		klog.Errorf("Could not start the prediction script: %s.", err)
+	}
+	time.Sleep(500 * time.Millisecond)
+	return &CPUProfileActuator{
+		cfg:    cfg,
+		tracer: tracer,
+		apps:   apps,
+	}
+}

--- a/pkg/planner/actuators/profiling/cpu_profile_test.go
+++ b/pkg/planner/actuators/profiling/cpu_profile_test.go
@@ -1,0 +1,786 @@
+package profiling
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/intel/intent-driven-orchestration/pkg/common"
+	"github.com/intel/intent-driven-orchestration/pkg/planner"
+
+	appsV1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog/v2"
+)
+
+// dummyTracerCpu allows us to control what information we give to the actuator.
+type dummyTracerCPU struct{}
+
+func (d dummyTracerCPU) TraceEvent(_ common.State, _ common.State, _ []planner.Action) {
+	klog.Fatalf("implement me")
+}
+
+// for model with lookup table (not current)
+func (d dummyTracerCPU) GetEffect(_ string, _ string, profileName string,
+	_ int, constructor func() interface{}) (interface{}, error) {
+	if profileName == "default/blurb" || profileName == "default/p99" {
+		return nil, fmt.Errorf("no model was found - retuning error")
+	}
+
+	tmp := constructor().(*CPUProfileEffect)
+	// the values will affect the latency and the tests results
+	//lookupTable synthetically populated
+	tmp.LookupTable = map[int64][]IndividualCPUEffect{
+		500: {
+			{ID: 1, Latency: 120, Mean: 120, Sdt: 0},
+			{ID: 2, Latency: 103, Mean: 103, Sdt: 0},
+			{ID: 3, Latency: 100, Mean: 100, Sdt: 0},
+			{ID: 4, Latency: 90, Mean: 90, Sdt: 0},
+		},
+		1000: {
+			{ID: 1, Latency: 110, Mean: 110, Sdt: 0},
+			{ID: 2, Latency: 101, Mean: 101, Sdt: 0},
+			{ID: 3, Latency: 96, Mean: 96, Sdt: 0},
+			{ID: 4, Latency: 85, Mean: 85, Sdt: 0},
+		},
+		1500: {
+			{ID: 1, Latency: 90, Mean: 90, Sdt: 0},
+			{ID: 2, Latency: 73, Mean: 73, Sdt: 0},
+			{ID: 3, Latency: 70, Mean: 70, Sdt: 0},
+			{ID: 4, Latency: 60, Mean: 60, Sdt: 0},
+		},
+	}
+	return tmp, nil
+}
+
+// CPUProfileActuatorFixture represents a fixture for testing.
+type CPUProfileActuatorFixture struct {
+	test    *testing.T
+	client  *fake.Clientset
+	objects []runtime.Object
+}
+
+// newCPUProfileActuatorFixture initializes a new fixture for testing.
+func newCPUProfileActuatorFixture(t *testing.T) *CPUProfileActuatorFixture {
+	f := &CPUProfileActuatorFixture{}
+	f.test = t
+	return f
+}
+
+// newCPUProfileTestActuator initializes an actuator for testing.
+func (f *CPUProfileActuatorFixture) newCPUProfileTestActuator(proactive bool) *CPUProfileActuator {
+	f.client = fake.NewSimpleClientset(f.objects...)
+	//cpuProfiles populated with Vanilla defined profiles
+	cpuProfiles := []CPUProfile{
+		{
+			ID:         1,
+			Name:       "standard",
+			CPUManager: 0,
+			Affinity:   1,
+			Settings:   map[string]string{},
+		},
+		{
+			ID:         2,
+			Name:       "exclusive",
+			CPUManager: 0,
+			Affinity:   1,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+			},
+		},
+		{
+			ID:         3,
+			Name:       "numa_exclusive",
+			CPUManager: 0,
+			Affinity:   1,
+			Settings: map[string]string{
+				"topology_policy": "single-numa-node",
+			},
+		},
+		{
+			ID:         4,
+			Name:       "pexclusive",
+			CPUManager: 0,
+			Affinity:   1,
+			Settings: map[string]string{
+				"full_pcpu_only": "true",
+			},
+		},
+	}
+
+	cfg := CPUProfileConfig{
+		Interpreter: "python3",
+		Analytics:   "test_analyze.py",
+		Prediction:  "test_predict.py",
+	
+		CPUMax:      10000,
+		CPUProfiles: cpuProfiles,
+	}
+	if proactive {
+		klog.Fatalf("proactive actions are not yet implemented")
+	}
+	actuator := NewCPUProfileActuator(f.client, dummyTracerCPU{}, cfg)
+
+	return actuator
+}
+
+// getInt32Pointer return a ref to an int32.
+func getInt32Pointer(value int32) *int32 {
+	val := value
+	return &val
+}
+
+// createDeployment instantiates deployment workload for testing.
+func createDeployment() runtime.Object {
+	return &appsV1.Deployment{
+		TypeMeta: metaV1.TypeMeta{},
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "my-deployment",
+			Namespace: "default",
+			Annotations: map[string]string{ // annotations at the deployment level
+				CPUProfileKey: "1",
+			},
+		},
+		Spec: appsV1.DeploymentSpec{
+			Replicas: getInt32Pointer(1),
+			Selector: &metaV1.LabelSelector{MatchLabels: map[string]string{
+				"app": "my-function"}},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metaV1.ObjectMeta{
+					Annotations: map[string]string{
+						CPUProfileKey: "1", // annotation at the pod level
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "my-function",
+							Resources: v1.ResourceRequirements{
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2000m"),
+									v1.ResourceMemory: {}},
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("1000m"),
+									v1.ResourceMemory: {}}},
+						},
+						{Name: "my-function-2",
+							Resources: v1.ResourceRequirements{
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("123m"),
+									v1.ResourceMemory: {}}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createReplicaSet() runtime.Object {
+	return &appsV1.ReplicaSet{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "my-replicaset",
+			Namespace: "default",
+			Annotations: map[string]string{ // annotation at RS level
+				CPUProfileKey: "1",
+			},
+		},
+		Spec: appsV1.ReplicaSetSpec{
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metaV1.ObjectMeta{
+					Annotations: map[string]string{
+						CPUProfileKey: "1", // annotation at pod level
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "pod0123",
+							Resources: v1.ResourceRequirements{
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU: resource.MustParse("200"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Tests for success.
+
+// TestCPUProfileNextStateForSuccess tests for success.
+func TestCPUProfileNextStateForSuccess(t *testing.T) {
+	f := newCPUProfileActuatorFixture(t)
+	actuator := f.newCPUProfileTestActuator(false)
+	state := common.State{Intent: struct {
+		Key        string
+		Priority   float64
+		TargetKey  string
+		TargetKind string
+		ActivelyManaged bool
+		Objectives map[string]float64
+		Tolerations map[string]float64
+	}{
+		Key:        "default/my-objective",
+		Priority:   1.0,
+		TargetKey:  "default/my-deployment",
+		TargetKind: "Deployment",
+		Objectives: map[string]float64{"p99": 100.0},
+	},
+		CurrentPods: map[string]common.PodState{
+			"pod0": {
+				NodeName:     "node0",
+				Availability: 1.0,
+				State:        "Running",
+				QoSClass:     "Guaranteed",
+			},
+		},
+		Resources: map[string]int64{
+			"1_cpu_requests": 1000,
+			"1_cpu_limits":   1000,
+		},
+		Annotations: map[string]string{
+			CPUProfileKey: "1",
+		},
+	}
+	goal := common.State{}
+	goal.Intent.Priority = 1.0
+	goal.Intent.Objectives = map[string]float64{"p99": 90.0}
+	profiles := map[string]common.Profile{"p99": {ProfileType: common.ProfileTypeFromText("latency")}}
+	actuator.NextState(&state, &goal, profiles)
+}
+
+// TestCPUProfilePerformForSuccess tests for success.
+func TestCPUProfilePerformForSuccess(t *testing.T) {
+	f := newCPUProfileActuatorFixture(t)
+	f.objects = append(f.objects, createDeployment())
+	actuator := f.newCPUProfileTestActuator(false)
+	s0 := common.State{
+		Intent: common.Intent{TargetKey: "default/my-deployment", TargetKind: "Deployment"},
+		Resources: map[string]int64{
+			"1_cpu_limits": 100,
+		},
+		Annotations: map[string]string{
+			CPUProfileKey: "1",
+		},
+	}
+	s0.Intent.TargetKind = "Deployment"
+	plan := []planner.Action{{Name: actionName, Properties: map[string]string{"id": "2"}}}
+	actuator.Perform(&s0, plan)
+}
+
+// TestCPUProfileEffectForSuccess tests for success.
+func TestCPUProfileEffectForSuccess(t *testing.T) {
+	f := newCPUProfileActuatorFixture(t)
+	actuator := f.newCPUProfileTestActuator(false)
+	s0 := common.State{}
+	profiles := map[string]common.Profile{"p99": {ProfileType: common.ProfileTypeFromText("latency")}}
+	actuator.Effect(&s0, profiles)
+}
+
+// TestCPUProfileGetResourcesForSuccess tests for success.
+func TestCPUProfileGetResourcesForSuccess(_ *testing.T) {
+	s0 := common.State{Resources: map[string]int64{}}
+	getResourceValues(&s0, Vanilla)
+}
+
+// TestCPUProfileGetCPUProfileForSuccess tests for success.
+func TestCPUProfileGetCPUProfileForSuccess(t *testing.T) {
+	f := newCPUProfileActuatorFixture(t)
+	actuator := f.newCPUProfileTestActuator(false)
+	state := common.State{
+		CurrentPods: map[string]common.PodState{
+			"pod0": {
+				NodeName:     "node0",
+				Availability: 1.0,
+				State:        "Running",
+			},
+		},
+		Annotations: map[string]string{
+			CPUProfileKey: "1",
+		},
+	}
+	CProfile, _ := actuator.getCPUProfile(&state)
+	if CProfile == nil {
+		t.Error()
+	}
+}
+
+// Tests for failure.
+
+// TestCPUProfileNextStateForFailure tests for failure.
+func TestCPUProfileNextStateForFailure(t *testing.T) {
+	f := newCPUProfileActuatorFixture(t)
+	actuator := f.newCPUProfileTestActuator(false)
+
+	state := common.State{
+		Intent: struct {
+			Key        string
+			Priority   float64
+			TargetKey  string
+			TargetKind string
+			ActivelyManaged bool
+			Objectives map[string]float64
+			Tolerations map[string]float64
+		}{
+			Key:        "default/my-objective",
+			Priority:   1.0,
+			TargetKey:  "default/my-deployment",
+			TargetKind: "Deployment",
+			Objectives: map[string]float64{"p99": 10.0},
+		},
+		CurrentPods: map[string]common.PodState{
+			"pod0": {
+				NodeName:     "node0",
+				Availability: 1.0,
+				State:        "Running",
+				QoSClass:     "Guaranteed",
+			},
+		},
+		Resources: map[string]int64{
+			"1_cpu_requests": 100,
+			"1_cpu_limits":   100,
+		},
+		Annotations: map[string]string{
+			CPUProfileKey: "11",
+		},
+	}
+	goal := common.State{}
+	goal.Intent.Objectives = map[string]float64{
+		"default/p99":          6.0,
+		"default/rps":          0.0,
+		"default/availability": 0.999,
+	}
+	profiles := map[string]common.Profile{
+		"default/p99": {ProfileType: common.ProfileTypeFromText("latency")},
+	}
+
+	// CPUProfile ID out of range
+	states, _, _ := actuator.NextState(&state, &goal, profiles)
+	if states != nil {
+		t.Errorf("Expected empty results set as CPUProfile doesnt match any ID in the config. - got: %v", states)
+	}
+	podState := state.CurrentPods["pod0"]
+	state.Annotations[CPUProfileKey] = "1"
+	state.CurrentPods["pod0"] = podState
+
+	// no data in knowledge base.
+	profiles["default/throughput"] = common.Profile{ProfileType: common.ProfileTypeFromText("throughput")}
+	profiles["default/blurb"] = common.Profile{ProfileType: common.ProfileTypeFromText("latency")}
+	state.Intent.Objectives["default/blurb"] = 42.0
+	state.Intent.Objectives["default/throughput"] = 200.0
+	states, _, _ = actuator.NextState(&state, &goal, profiles)
+	if len(state.CurrentData) > 0 {
+		t.Errorf("Expected empty results set as knowledge base is corrupt/empty. - got: %v", states)
+	}
+	delete(profiles, "default/throughput")
+	delete(profiles, "default/blurb")
+	delete(state.Intent.Objectives, "default/throughput")
+	delete(state.Intent.Objectives, "default/blurb")
+
+	profiles["p99"] = common.Profile{ProfileType: common.ProfileTypeFromText("latency")}
+	goal.Intent.Objectives = map[string]float64{
+		"p99": 90.0,
+	}
+	// negative resource limit.
+	state.Resources = map[string]int64{
+		"1_cpu_limits": -100,
+	}
+	states, _, _ = actuator.NextState(&state, &goal, profiles)
+	if len(state.CurrentData) > 0 {
+		t.Errorf("Expected empty results - got: %v", states)
+	}
+
+	// too high resource limit
+	state.Resources = map[string]int64{
+		"1_cpu_limits": 100000,
+	}
+	states, _, _ = actuator.NextState(&state, &goal, profiles)
+	if len(state.CurrentData) > 0 {
+		t.Errorf("Expected empty results  - got: %v", states)
+	}
+
+	//TODO: more cpus than max for isolated CPU profile
+}
+
+// TestCPUProfilePerformForFailure tests for failure.
+func TestCPUProfilePerformForFailure(t *testing.T) {
+	f := newCPUProfileActuatorFixture(t)
+	f.objects = []runtime.Object{}
+	actuator := f.newCPUProfileTestActuator(false)
+
+	// deployment does not exist!
+	s0 := common.State{
+		Intent: common.Intent{TargetKey: "default/my-deployment", TargetKind: "Deployment"},
+		Annotations: map[string]string{
+			CPUProfileKey: "1",
+		},
+	}
+	plan := []planner.Action{
+		{Name: actionName, Properties: map[string]string{"id": "2"}},
+	}
+	actuator.Perform(&s0, plan)
+
+	expectedActions := []string{"get"}
+	fmt.Println(f.client.Actions())
+	if len(f.client.Actions()) != len(expectedActions) {
+		t.Errorf("this should not happen - should be equal length.")
+		return
+	}
+	for i, item := range expectedActions {
+		if f.client.Actions()[i].GetVerb() != item {
+			t.Errorf("Expected: %s - got: %s.", item, f.client.Actions()[i].GetVerb())
+		}
+
+	}
+
+	// replicaset does not exist!
+	f.client.ClearActions()
+	s1 := common.State{
+		Intent: common.Intent{TargetKey: "default/my-rs", TargetKind: "ReplicaSet"},
+		Annotations: map[string]string{
+			CPUProfileKey: "1",
+		},
+	}
+	plan = []planner.Action{
+		{Name: actionName, Properties: map[string]string{"id": "2"}},
+	}
+	actuator.Perform(&s1, plan)
+	expectedActions = []string{"get"}
+
+	if len(f.client.Actions()) != len(expectedActions) {
+		t.Errorf("this should not happen - should be equal length.")
+		return
+	}
+	for i, item := range expectedActions {
+		if f.client.Actions()[i].GetVerb() != item {
+			t.Errorf("Expected: %s - got: %s.", item, f.client.Actions()[i].GetVerb())
+		}
+	}
+
+	// plan property is invalid.
+	f.client.ClearActions()
+	plan = []planner.Action{
+		{Name: actionName, Properties: map[string]string{"profile": "5"}},
+	}
+	actuator.Perform(&s0, plan)
+	if len(f.client.Actions()) != 0 {
+		t.Errorf("This is not expected: %v", f.client.Actions())
+	}
+
+}
+
+// TestCPUProfileGetResourcesForFailure tests for failure
+func TestCPUProfileGetResourcesForFailure(t *testing.T) {
+	s0 := common.State{Resources: map[string]int64{"a_cpu_limits": 100}}
+	res := getResourceValues(&s0, Vanilla)
+	if res != 0 {
+		t.Errorf("Should have been 0 - was: %d.", res)
+	}
+}
+
+// TestCPUProfileCPUProfileForFailure tests for failure
+func TestCPUProfileGetCPUProfileForFailure(t *testing.T) {
+	f := newCPUProfileActuatorFixture(t)
+	actuator := f.newCPUProfileTestActuator(false)
+	state := common.State{
+		CurrentPods: map[string]common.PodState{
+			"pod0": {
+				NodeName:     "node0",
+				Availability: 1.0,
+				State:        "Running",
+			},
+		},
+		Annotations: map[string]string{
+			CPUProfileKey: "99",
+		},
+	}
+	CProfile, _ := actuator.getCPUProfile(&state)
+	if CProfile != nil {
+		t.Errorf("Should have been nil - was: %v.", CProfile)
+	}
+}
+
+// Tests for sanity.
+
+// TestCPUProfileNextStateForSanity tests for sanity.
+func TestCPUProfileNextStateForSanity(t *testing.T) {
+	f := newCPUProfileActuatorFixture(t)
+	actuator := f.newCPUProfileTestActuator(false)
+
+	state := common.State{
+		Intent: struct {
+			Key        string
+			Priority   float64
+			TargetKey  string
+			TargetKind string
+			ActivelyManaged bool
+			Objectives map[string]float64
+			Tolerations map[string]float64
+		}{
+			Key:        "default/my-objective",
+			Priority:   1.0,
+			TargetKey:  "default/my-deployment",
+			TargetKind: "Deployment",
+			Objectives: map[string]float64{"p99": 60.0},
+		},
+		CurrentPods: map[string]common.PodState{
+			"pod0": {
+				NodeName:     "node0",
+				Availability: 1.0,
+				State:        "Running",
+				QoSClass:     "Guaranteed",
+			},
+		},
+		Resources: map[string]int64{
+			"1_cpu_limits":   1500,
+			"1_cpu_requests": 1500,
+		},
+		CurrentData: make(map[string]map[string]float64),
+		Annotations: map[string]string{
+			CPUProfileKey: "4",
+		},
+	}
+	goal := common.State{}
+	goal.Intent.Objectives = map[string]float64{"p99": 65.0}
+	profiles := map[string]common.Profile{
+		"p99": {ProfileType: common.ProfileTypeFromText("latency")},
+		"p95": {ProfileType: common.ProfileTypeFromText("latency")},
+	}
+
+	// if pod is not in Guarantted QoSClass
+	_, _, actions := actuator.NextState(&state, &goal, profiles)
+	if len(actions) != 0 {
+		t.Errorf("Should be empty, was: %v.", actions)
+	}
+
+	podState := state.CurrentPods["pod0"]
+	podState.QoSClass = "Guaranteed"
+	state.CurrentPods["pod0"] = podState
+
+	// if me meet the goal & using the most isolated cpu profile -> do nothing -- checked in perform function
+	_, _, actions = actuator.NextState(&state, &goal, profiles)
+	if len(actions) != 0 {
+		t.Errorf("Should be empty, was: %v.", actions)
+	}
+
+	// if we've already looked at cpu profiling in this planning cycle, skip...
+	goal.Intent.Objectives["p99"] = 30
+	state.CurrentData[actionName] = map[string]float64{"actionName": 1}
+	_, _, actions = actuator.NextState(&state, &goal, profiles)
+	if len(actions) != 0 {
+		t.Errorf("Should be empty, was: %v.", actions)
+	}
+
+	// now this should work...
+	state.Intent.Objectives["p99"] = 100
+	state.Annotations[CPUProfileKey] = "1"
+	goal.Intent.Objectives["p99"] = 65
+	delete(state.CurrentData, actionName)
+	_, _, actions = actuator.NextState(&state, &goal, profiles)
+	fmt.Printf("Objectives in state: %+v\n", state.Intent.Objectives)
+	if len(actions) < 1 || actions[0].Properties.(map[string]string)["id"] != "4" {
+		t.Errorf("Expected one action to set cpu profile id to 4 - got: %v", actions)
+	}
+
+	// if we are better than goal -> switch to a lower profile Id.
+	state.Intent.Objectives["p99"] = 60.0
+	goal.Intent.Objectives["p99"] = 75.0
+	_, _, actions = actuator.NextState(&state, &goal, profiles)
+	found := false
+	for _, action := range actions {
+		if id, ok := action.Properties.(map[string]int)["id"]; ok && id == 2 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected at least one action to set cpu profile id to 2 - got: %v", actions)
+	}
+	// multiple objectives (conflicts - requiring different cpu profiles)
+	state.Intent.Objectives["p95"] = 120
+	goal.Intent.Objectives["p95"] = 60
+	_, _, actions = actuator.NextState(&state, &goal, profiles)
+	if len(actions) < 1 || actions[0].Properties.(map[string]int)["id"] != 4 {
+		t.Errorf("Expected one action to set cpu profile id to 4 - got: %v", actions)
+	}
+
+	// too strict of a goal.
+	goal.Intent.Objectives["p99"] = 1.0
+	states, utilities, actions := actuator.NextState(&state, &goal, profiles)
+	if len(states) != 0 || len(utilities) != 0 || len(actions) != 0 {
+		t.Errorf("Result sets should be empty: %v, %v, %v.", states, utilities, actions)
+	}
+
+
+	// ensure an "empty" state does not crash the actuator.
+	actuator = f.newCPUProfileTestActuator(false)
+	delete(goal.Intent.Objectives, "p95")
+	goal.Intent.Objectives["p99"] = 120
+	emptyState := common.State{
+		Intent: struct {
+			Key        string
+			Priority   float64
+			TargetKey  string
+			TargetKind string
+			ActivelyManaged bool
+			Objectives map[string]float64
+			Tolerations map[string]float64
+		}{
+			Key:        "default/my-objective",
+			Priority:   1.0,
+			TargetKey:  "default/my-deployment",
+			TargetKind: "Deployment",
+			Objectives: map[string]float64{"p99": 250.0},
+		},
+	}
+	_, _, actions = actuator.NextState(&emptyState, &goal, profiles)
+	if len(actions) != 0 {
+		t.Errorf("Should contain no action; was: %v", actions)
+	}
+}
+
+// TestCPUProfilePerformForSanity tests for sanity.
+func TestCPUProfilePerformForSanity(t *testing.T) {
+	f := newCPUProfileActuatorFixture(t)
+	f.objects = append(f.objects, createDeployment())
+	actuator := f.newCPUProfileTestActuator(false)
+
+	// test for deployment.
+	s0 := common.State{
+		Intent: common.Intent{TargetKey: "default/my-deployment", TargetKind: "Deployment"},
+		Annotations: map[string]string{
+			CPUProfileKey: "1",
+		},
+	}
+	plan := []planner.Action{
+		{Name: actionName, Properties: map[string]string{"id": "3"}},
+	}
+	actuator.Perform(&s0, plan)
+	expectedActions := []string{"get", "update"}
+	for i, action := range f.client.Actions() {
+		if action.GetVerb() != expectedActions[i] {
+			t.Errorf("Expected %s - got %s.", expectedActions[i], action)
+		}
+	}
+	if len(expectedActions) != len(f.client.Actions()) {
+		t.Errorf("Expecting action list to be equal length: %v, %v", expectedActions, f.client.Actions())
+	}
+	updatedObject, _ := f.client.AppsV1().Deployments("default").Get(context.TODO(), "my-deployment", metaV1.GetOptions{})
+	res := updatedObject.Spec.Template.ObjectMeta.Annotations
+	val, ok := res[CPUProfileKey]
+	if val != "3" || !ok {
+		t.Errorf("Request should have been 3; was: %v", val)
+	}
+	f.client.ClearActions()
+
+	// planned cpu profile same as current one
+	s0.Annotations[CPUProfileKey] = "4"
+	plan = []planner.Action{
+		{Name: actionName, Properties: map[string]string{"id": "4"}},
+	}
+	actuator.Perform(&s0, plan)
+	for _, action := range f.client.Actions() {
+		if len(action.GetVerb()) != 0 {
+			t.Errorf("Expected no action - got %s.", action.GetVerb())
+		}
+	}
+	f.client.ClearActions()
+
+	// test for replicaset.
+	f.client.ClearActions()
+	f.objects = []runtime.Object{createReplicaSet()}
+	actuator = f.newCPUProfileTestActuator(false)
+	s0.Intent.TargetKey = "default/my-replicaset"
+	s0.Intent.TargetKind = "ReplicaSet"
+	s0.Annotations[CPUProfileKey] = "1"
+	plan = []planner.Action{
+		{Name: actionName, Properties: map[string]string{"id": "3"}},
+	}
+	actuator.Perform(&s0, plan)
+	expectedActions = []string{"get", "update"}
+	for i, action := range f.client.Actions() {
+		if action.GetVerb() != expectedActions[i] {
+			t.Errorf("Expected %s - got %s.", expectedActions[i], action)
+		}
+	}
+	if len(expectedActions) != len(f.client.Actions()) {
+		t.Errorf("Expecting action list to be equal length: %v, %v", expectedActions, f.client.Actions())
+	}
+	updatedRS, _ := f.client.AppsV1().ReplicaSets("default").Get(context.TODO(), "my-replicaset", metaV1.GetOptions{})
+	//res = updatedRS.Spec.Template.Annotations
+	res = updatedRS.Spec.Template.ObjectMeta.Annotations
+	val, ok = res[CPUProfileKey]
+	if val != "3" || !ok {
+		t.Errorf("Request should have been 3; was: %v", val)
+	}
+	f.client.ClearActions()
+
+	// planned cpu profile same as current one
+	s0.Annotations[CPUProfileKey] = "4"
+	plan = []planner.Action{
+		{Name: actionName, Properties: map[string]string{"id": "4"}},
+	}
+	actuator.Perform(&s0, plan)
+	for _, action := range f.client.Actions() {
+		if len(action.GetVerb()) != 0 {
+			t.Errorf("Expected no action - got %s.", action.GetVerb())
+		}
+	}
+}
+
+// TestCPUProfileEffectForSanity tests for sanity.
+func TestCPUProfileEffectForSanity(t *testing.T) {
+	f := newCPUProfileActuatorFixture(t)
+	// this will "just" trigger a python script.
+	state := common.State{Intent: struct {
+		Key        string
+		Priority   float64
+		TargetKey  string
+		TargetKind string
+		ActivelyManaged bool
+		Objectives map[string]float64
+		Tolerations map[string]float64
+	}{Key: "default/my-objective", Priority: 1.0, TargetKey: "default/my-deployment",
+		TargetKind: "Deployment", Objectives: map[string]float64{"p99": 20.0}}}
+	profiles := map[string]common.Profile{"p99": {ProfileType: common.ProfileTypeFromText("latency")}}
+	actuator := f.newCPUProfileTestActuator(false)
+	actuator.Effect(&state, profiles)
+
+	// check with None.
+	actuator.cfg.Analytics = "None"
+	actuator.Effect(&state, profiles)
+}
+
+// TestCPUProfileGetResourcesForSuccess tests for sanity.
+func TestCPUProfileGetResourcesForSanity(t *testing.T) {
+	s0 := common.State{Resources: map[string]int64{}}
+	res := getResourceValues(&s0, Vanilla)
+	if res != 0 {
+		t.Errorf("Should have been 0 - was: %v", res)
+	}
+
+	// request defined.
+	s0.Resources["0_cpu_requests"] = 200
+	res = getResourceValues(&s0, Vanilla)
+	if res != 200 {
+		t.Errorf("Should have been 200 - was: %v", res)
+	}
+	// limits defined.
+	s0.Resources["0_cpu_limits"] = 400
+	res = getResourceValues(&s0, Vanilla)
+	if res != 400 {
+		t.Errorf("Should have been 400 - was: %v", res)
+	}
+	// the last container matters.
+	s0.Resources["1_cpu_limits"] = 100
+	res = getResourceValues(&s0, Vanilla)
+	if res != 100 {
+		t.Errorf("Should have been 100 - was: %v", res)
+	}
+}

--- a/pkg/planner/actuators/profiling/test_analyze.py
+++ b/pkg/planner/actuators/profiling/test_analyze.py
@@ -1,0 +1,6 @@
+"""
+Empty script for testing.
+"""
+
+if __name__ == '__main__':
+    print('done.')

--- a/pkg/planner/actuators/profiling/test_predict.py
+++ b/pkg/planner/actuators/profiling/test_predict.py
@@ -1,0 +1,216 @@
+"""
+Script for testing.
+"""
+
+import argparse
+import json
+import logging
+import sys
+
+from wsgiref.simple_server import make_server
+
+logging.basicConfig(level=logging.INFO)
+
+TEST_DATA = {
+    'default/my-objective': {
+        500: {
+            1: {
+                'p99': 120.0,
+                'p95': 120.0
+            },
+            2: {
+                'p99': 103.0,
+                'p95': 103.0
+            },
+            3: {
+                'p99': 100.0,
+                'p95': 100.0
+            },
+            4: {
+                'p99': 90.0,
+                'p95': 90.0
+            },
+        },
+        1000: {
+            1: {
+                'p99': 110.0,
+                'p95': 110.0
+            },
+            2: {
+                'p99': 101.0,
+                'p95': 101.0
+            },
+            3: {
+                'p99': 96.0,
+                'p95': 96.0
+            },
+            4: {
+                'p99': 85.0,
+                'p95': 85.0
+            },
+        },
+        1500: {
+            1: {
+                'p99': 90.0,
+                'p95': 90.0
+            },
+            2: {
+                'p99': 73.0,
+                'p95': 73.0
+            },
+            3: {
+                'p99': 70.0,
+                'p95': 70.0
+            },
+            4: {
+                'p99': 60.0,
+                'p95': 60.0
+            },
+        }
+    },
+    "default/my-intent": {
+        1000: {
+            1: {
+                'default/p99latency': 290.0,
+                'default/p95latency': 250.0,
+                'default/p50latency': 150.0
+            },
+            2: {
+                'default/p99latency': 200.0,
+                'default/p95latency': 200.0,
+                'default/p50latency': 120.0
+            },
+            3: {
+                'default/p99latency': 180.0,
+                'default/p95latency': 180.0,
+                'default/p50latency': 100.0
+            },
+            4: {
+                'default/p99latency': 150.0,
+                'default/p95latency': 150.0,
+                'default/p50latency': 95.0
+            },
+        },
+        2000: {
+            1: {
+                'default/p99latency': 230.0,
+                'default/p95latency': 230.0,
+                'default/p50latency': 130.0
+            },
+            2: {
+                'default/p99latency': 190.0,
+                'default/p95latency': 190.0,
+                'default/p50latency': 105.0
+            },
+            3: {
+                'default/p99latency': 120.0,
+                'default/p95latency': 150.0,
+                'default/p50latency': 90.0
+            },
+            4: {
+                'default/p99latency': 90.0,
+                'default/p95latency': 120.0,
+                'default/p50latency': 85.0
+            },
+        },
+        3000: {
+            1: {
+                'default/p99latency': 190.0,
+                'default/p95latency': 190.0,
+                'default/p50latency': 90.0
+            },
+            2: {
+                'default/p99latency': 120.0,
+                'default/p95latency': 120.0,
+                'default/p50latency': 75.0
+            },
+            3: {
+                'default/p99latency': 89.0,
+                'default/p95latency': 89.0,
+                'default/p50latency': 70.0
+            },
+            4: {
+                'default/p99latency': 54.0,
+                'default/p95latency': 54.0,
+                'default/p50latency': 55.0
+            },
+        },
+        4000: {
+            1: {
+                'default/p99latency': 150.0,
+                'default/p95latency': 150.0,
+                'default/p50latency': 70.0
+            },
+            2: {
+                'default/p99latency': 95.0,
+                'default/p95latency': 95.0,
+                'default/p50latency': 65.0
+            },
+            3: {
+                'default/p99latency': 70.0,
+                'default/p95latency': 70.0,
+                'default/p50latency': 50.0
+            },
+            4: {
+                'default/p99latency': 46.0,
+                'default/p95latency': 39.0,
+                'default/p50latency': 35.0
+            },
+        },
+    }
+}
+
+
+def predict_app(environ, start_response):
+    """
+    Predicts the effect on a latency target, or return -1.0.
+    """
+    try:
+        body_size = int(environ.get('CONTENT_LENGTH', 0))
+    except ValueError:
+        body_size = 0
+
+    request_body = environ['wsgi.input'].read(body_size)
+    body = json.loads(request_body)
+
+    name = body['name']
+    target = body['target']
+    cpus = body['cpus']
+    cpuprofile = body['cpu_profile']
+
+    if cpus is None or cpuprofile is None:
+        sys.exit('missing values!')
+
+    res = -1.0
+    if name in TEST_DATA and \
+        cpus in TEST_DATA[name] and \
+        cpuprofile in TEST_DATA[name][cpus] and \
+            target in TEST_DATA[name][cpus][cpuprofile]:
+        res = TEST_DATA[name][cpus][cpuprofile][target]
+        print(f"Predicted value for {name}, {cpus}, {cpuprofile}, {target}: {res}")
+
+
+    status = '200 OK'
+    headers = [('Content-type', 'application/json')]
+    start_response(status, headers)
+
+    tmp = json.dumps({'val': res})
+    return [tmp.encode()]
+
+
+def serve(args):
+    """
+    Launch a wsgi ref server.
+    """
+    logging.info('Listening on port: %s', int(args.port))
+    with make_server('127.0.0.1', args.port, predict_app) as httpd:
+        httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--port', type=int, default=8000,
+                        help='Port to listen on.')
+    ARGS = parser.parse_args()
+    sys.stdout.write(str(serve(ARGS)))
+    sys.stdout.flush()

--- a/pkg/planner/actuators/profiling/vanilla_cpu_manager.go
+++ b/pkg/planner/actuators/profiling/vanilla_cpu_manager.go
@@ -1,0 +1,260 @@
+package profiling
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/intel/intent-driven-orchestration/pkg/common"
+)
+
+const defaultPreferredWeight = 1
+
+func toVanillaProfile(pod *v1.PodTemplateSpec, newCPUProfile CPUProfile, currentCPUProfile CPUProfile) error {
+	switch currentCPUProfile.CPUManager {
+	case CPUControlPlane:
+		return fmt.Errorf("switching from CPU Control Plane profiles is not yet supported")
+		
+	case Vanilla:
+		err := updateNodeAffinity(pod, newCPUProfile, currentCPUProfile)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func updateNodeAffinity(pod *v1.PodTemplateSpec, newCPUProfile CPUProfile, currentCPUProfile CPUProfile) error {
+	//The profile will be applied at the level of the pod (all containers)
+
+	// 1. clean up current affinities
+	nodeAffinity, err := getNodeAffinity(&pod.Spec)
+	if err != nil {
+		return err
+	}
+	currentSettings := currentCPUProfile.Settings
+
+	// delete node affinities matching current profile settings
+	// warning: a conflict can be caused if these affinities are also used for other purposes
+	if len(currentSettings) > 0 {
+		deleteNodeAffinities(nodeAffinity, currentSettings)
+	}
+
+	// 2. set up new affinities
+	nodeSelectorTerms, err := mapProfileToNodeSelectors(newCPUProfile)
+	for i, term := range nodeSelectorTerms {
+		klog.Infof("NodeSelectorTerm %d: %+v", i, term)
+	}
+	if err != nil {
+		return err
+	}
+
+	if len(nodeSelectorTerms) > 0 {
+		err = setNodeAffinity(&pod.Spec, nodeSelectorTerms, newCPUProfile.Affinity)
+		if err != nil {
+			return err
+		}
+		klog.Infof("Pod NodeSelector: %+v", pod.Spec.NodeSelector)
+	}
+	if pod.Spec.Affinity != nil && pod.Spec.Affinity.NodeAffinity != nil {
+		klog.Infof("Pod NodeAffinity: %+v", pod.Spec.Affinity.NodeAffinity)
+		if pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+			klog.Infof("Required NodeAffinity Terms: %+v", 
+					pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms)
+		}
+		if pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {
+			klog.Infof("Preferred NodeAffinity Terms: %+v", 
+					pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+		}
+	}
+	return nil
+}
+
+// mapProfileToNodeSelectors maps profile settings to corresonding nodeSelectorTerms
+func mapProfileToNodeSelectors(cpuProfile CPUProfile) ([]v1.NodeSelectorTerm, error) {
+
+	if len(cpuProfile.Settings) == 0 {
+		// no specific nodeSelectorTerms (no need to return an error for now)
+		return nil, nil
+	}
+
+	var nodeSelectorTerms []v1.NodeSelectorTerm
+	var matchExpressions []v1.NodeSelectorRequirement
+
+	// assumption: all the settings in the profile are used for node selection
+	for key, value := range cpuProfile.Settings {
+		strValue := fmt.Sprintf("%v", value)
+		matchExpressions = append(matchExpressions, v1.NodeSelectorRequirement{
+			Key:      key,
+			Operator: v1.NodeSelectorOpIn,
+			Values:   []string{strValue},
+		})
+	}
+
+	if len(matchExpressions) == 0 {
+		// no valid match expressions found (no need to return an error for now)
+		return nil, nil
+	}
+	nodeSelectorTerms = append(nodeSelectorTerms, v1.NodeSelectorTerm{
+		MatchExpressions: matchExpressions,
+	})
+
+	return nodeSelectorTerms, nil
+}
+
+// deleteNodeAffinities deletes node affinities that match elements in current settings.
+func deleteNodeAffinities(nodeAffinity *v1.NodeAffinity, currentSettings map[string]string) {
+
+	if nodeAffinity == nil {
+		return
+	}
+
+	// Helper function to check if any of the nodeSelectorTerms match the elements in settings of CPU profile.
+	matchesAny := func(term v1.NodeSelectorTerm) bool {
+		for _, expr := range term.MatchExpressions {
+			if value, exists := currentSettings[expr.Key]; exists {
+				strValue := fmt.Sprintf("%v", value)
+				for _, val := range expr.Values {
+					if val == strValue {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+
+	// Remove matching required affinities
+	if nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		var filteredTerms []v1.NodeSelectorTerm
+		for _, term := range nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+			if !matchesAny(term) {
+				filteredTerms = append(filteredTerms, term)
+			}
+		}
+		nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = filteredTerms
+	}
+
+	// Remove matching preferred affinities
+	if nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {
+		var filteredPreferredTerms []v1.PreferredSchedulingTerm
+		for _, preferredTerm := range nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+			if !matchesAny(preferredTerm.Preference) {
+				filteredPreferredTerms = append(filteredPreferredTerms, preferredTerm)
+			}
+		}
+		nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = filteredPreferredTerms
+	}
+}
+
+// getNodeAffinity returns the node affinity of the pod if it exists, or create a new one if it doesn't. (podAffinity & podAntiAffinity are ignored for now)
+func getNodeAffinity(podSpec *v1.PodSpec) (*v1.NodeAffinity, error) {
+	if podSpec == nil {
+		return nil, fmt.Errorf("pod.Spec is nil")
+	}
+	if podSpec.Affinity == nil {
+		podSpec.Affinity = &v1.Affinity{}
+	}
+	if podSpec.Affinity.NodeAffinity == nil {
+		podSpec.Affinity.NodeAffinity = &v1.NodeAffinity{}
+	}
+	return podSpec.Affinity.NodeAffinity, nil
+}
+
+// setNodeAffinity sets the node affinity of the podSpec based on the provided nodeSelectorTerms and affinity type.
+func setNodeAffinity(podSpec *v1.PodSpec, nodeSelectorTerms []v1.NodeSelectorTerm, affinity Affinity) error {
+
+	if podSpec == nil {
+		return fmt.Errorf("podSpec is nil")
+	}
+	if nodeSelectorTerms == nil || len(nodeSelectorTerms) == 0 {
+		klog.Warning("nodeSelectorTerms is nil or empty")
+	} else {
+		for i, term := range nodeSelectorTerms {
+			klog.Infof("nodeSelectorTerms[%d]: %+v", i, term)
+		}
+	}
+
+	switch affinity {
+	case Required:
+		// Preserve existing required affinity terms and append new ones
+		var requiredTerms []v1.NodeSelectorTerm
+
+		if podSpec.Affinity != nil && podSpec.Affinity.NodeAffinity != nil &&
+			podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+			requiredTerms = append(requiredTerms,
+				podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms...)
+		}
+
+		requiredTerms = append(requiredTerms, nodeSelectorTerms...)
+
+		if podSpec.Affinity == nil {
+			podSpec.Affinity = &v1.Affinity{}
+		}
+		if podSpec.Affinity.NodeAffinity == nil {
+			podSpec.Affinity.NodeAffinity = &v1.NodeAffinity{}
+		}
+		if podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+			podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
+		}
+		podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = requiredTerms
+
+	case Preferred:
+		// Preserve existing preferred affinity terms and append new ones
+		var preferredSchedulingTerms []v1.PreferredSchedulingTerm
+
+		if podSpec.Affinity != nil && podSpec.Affinity.NodeAffinity != nil &&
+			podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {
+			preferredSchedulingTerms = append(preferredSchedulingTerms,
+				podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution...)
+		}
+
+		for _, term := range nodeSelectorTerms {
+			preferredSchedulingTerms = append(preferredSchedulingTerms, v1.PreferredSchedulingTerm{
+				Weight:     defaultPreferredWeight,
+				Preference: term,
+			})
+		}
+
+		if podSpec.Affinity == nil {
+			podSpec.Affinity = &v1.Affinity{}
+		}
+		if podSpec.Affinity.NodeAffinity == nil {
+			podSpec.Affinity.NodeAffinity = &v1.NodeAffinity{}
+		}
+		podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = preferredSchedulingTerms
+	}
+	return nil
+}
+
+// getResourceValues return the cpu resources associated with the last container of a POD.
+func getVanillaResourceValues(state *common.State) int64 {
+	cpuLimit := int64(0)
+	cpuRequest := int64(0)
+	lastIndex := -1
+	for key, value := range state.Resources {
+		items := strings.Split(key, "_")
+		index, err := strconv.Atoi(items[0])
+		if err != nil {
+			klog.Errorf("Failed to convert: %v", err)
+			return 0
+		}
+		if items[1] == "cpu" && index >= lastIndex {
+			if items[2] == "requests" {
+				cpuRequest = value
+			} else if items[2] == "limits" {
+				cpuLimit = value
+				cpuRequest = value
+			}
+			lastIndex = index
+		}
+	}
+	if cpuLimit >= cpuRequest {
+		return cpuLimit
+	}
+	return cpuRequest
+}

--- a/pkg/tests/full_framework_test.go
+++ b/pkg/tests/full_framework_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/intel/intent-driven-orchestration/pkg/planner"
 	"github.com/intel/intent-driven-orchestration/pkg/planner/actuators"
 	"github.com/intel/intent-driven-orchestration/pkg/planner/actuators/platform"
+	"github.com/intel/intent-driven-orchestration/pkg/planner/actuators/profiling"
 	"github.com/intel/intent-driven-orchestration/pkg/planner/actuators/scaling"
 	"github.com/intel/intent-driven-orchestration/pkg/planner/astar"
 	appsV1 "k8s.io/api/apps/v1"
@@ -102,6 +103,43 @@ func (t fileTracer) GetEffect(name string, group string, profileName string, _ i
 			}
 		}
 		tmp.Popts = popt
+		return tmp, nil
+	} else if group == "profiling" {
+		// retrieve effect data
+		tmp := constructor().(*profiling.CPUProfileEffect)
+		lookupTable := map[int64][]profiling.IndividualCPUEffect{}
+		if lookupData, ok := data["lookupTable"].(map[string]interface{}); ok {
+			for i, v := range lookupData {
+				key, err := strconv.ParseInt(i, 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("Error parsing key %v: %v", i, err)
+				}
+				rawEffects, ok := v.([]interface{})
+				if !ok {
+					return nil, fmt.Errorf("Error asserting value for key %v: expected []interface{}", i)
+				}
+
+				var effects []profiling.IndividualCPUEffect
+				for _, rawEffect := range rawEffects {
+					effectMap, ok := rawEffect.(map[string]interface{})
+					if !ok {
+						return nil, fmt.Errorf("Error asserting element in key %v: expected map[string]interface{}", i)
+					}
+
+					effect := profiling.IndividualCPUEffect{
+						ID:      int(effectMap["ID"].(float64)),
+						Latency: effectMap["latency"].(float64),
+					}
+					effects = append(effects, effect)
+				}
+
+				lookupTable[key] = effects
+			}
+		} else {
+			return nil, fmt.Errorf("Error in data[lookupTable]")
+		}
+		tmp.LookupTable = lookupTable
+		fmt.Println("lookupTable: ", tmp.LookupTable)
 		return tmp, nil
 	}
 	return nil, nil
@@ -467,6 +505,7 @@ func (f *testFixture) setWorkloadState(pods map[string]map[string]interface{}, r
 			ObjectMeta: metaV1.ObjectMeta{
 				Name:      "function-deployment",
 				Namespace: metaV1.NamespaceDefault,
+				//Annotations: annotations,
 			},
 			Spec: appsV1.DeploymentSpec{
 				Replicas: &repl,
@@ -476,6 +515,9 @@ func (f *testFixture) setWorkloadState(pods map[string]map[string]interface{}, r
 					},
 				},
 				Template: coreV1.PodTemplateSpec{
+					ObjectMeta: metaV1.ObjectMeta{
+						Annotations: annotations, // Add annotations at the pod spec level
+					},
 					Spec: coreV1.PodSpec{
 						Containers: []coreV1.Container{
 							{
@@ -491,6 +533,21 @@ func (f *testFixture) setWorkloadState(pods map[string]map[string]interface{}, r
 			},
 		}
 		_, err := f.k8sClient.AppsV1().Deployments("default").Create(context.TODO(), deployment, metaV1.CreateOptions{})
+		if err != nil {
+			klog.Errorf("Could not add deployment: %v", err)
+		}
+	} else {
+		// Get list of pods managed by this deployment (res)
+		podList, err := f.k8sClient.CoreV1().Pods(res.Namespace).List(context.TODO(), metaV1.ListOptions{
+			LabelSelector: "app=sample-function",
+		})
+		if err == nil {
+			for _, pod := range podList.Items {
+				pod.Annotations = annotations
+				_, err = f.k8sClient.CoreV1().Pods("default").Update(context.TODO(), &pod, metaV1.UpdateOptions{})
+			}
+		}
+		_, err = f.k8sClient.AppsV1().Deployments("default").Update(context.TODO(), res, metaV1.UpdateOptions{})
 		if err != nil {
 			klog.Errorf("Could not add deployment: %v", err)
 		}
@@ -565,6 +622,12 @@ func (f *testFixture) setWorkloadState(pods map[string]map[string]interface{}, r
 			}
 		}
 	}
+
+	// Force informer resync to propagate the updated state
+	f.k8sInformer.Core().V1().Pods().Informer().GetIndexer().Resync()
+
+	// Wait for state propagation
+	time.Sleep(2 * time.Millisecond * timeoutInMillis)
 }
 
 // setupIntent defines the initial intent.
@@ -604,6 +667,7 @@ func (f *testFixture) setDesiredObjectives(name string, objectives map[string]fl
 	if err != nil {
 		klog.Errorf("Could not retrieve previous set intent: %v.", err)
 	}
+	fmt.Printf("Event current objectives: %v\n", myIntent.Spec.Objectives)
 	changed := false
 	myIntent = myIntent.DeepCopy()
 	myIntent.ResourceVersion += "1"
@@ -613,11 +677,43 @@ func (f *testFixture) setDesiredObjectives(name string, objectives map[string]fl
 			changed = true
 		}
 	}
+
+	// check new objectives
+	for name, value := range objectives {
+		found := false
+		for _, existing := range myIntent.Spec.Objectives {
+			if existing.Name == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			// Add new objective
+			newObjective := v1alpha1.TargetObjective{
+				Name:       name,
+				MeasuredBy: name,
+				Value:      value,
+			}
+			myIntent.Spec.Objectives = append(myIntent.Spec.Objectives, newObjective)
+			changed = true
+		}
+	}
+	// Remove objectives that are no longer present in the new objectives map
+	var updatedObjectives []v1alpha1.TargetObjective
+	for _, objv := range myIntent.Spec.Objectives {
+		if _, exists := objectives[objv.Name]; exists {
+			updatedObjectives = append(updatedObjectives, objv)
+		} else {
+			changed = true
+		}
+	}
+	myIntent.Spec.Objectives = updatedObjectives
 	if changed {
 		_, err = f.intentClient.IdoV1alpha1().Intents(tmp[0]).Update(context.TODO(), myIntent, metaV1.UpdateOptions{})
 		if err != nil {
 			klog.Errorf("Could not update intent: %v.", err)
 		}
+		fmt.Printf("Event updated objectives: %v\n", myIntent.Spec.Objectives)
 	} else {
 		klog.Infof("No change in intent - will not update: %v", objectives)
 	}
@@ -695,15 +791,21 @@ func runTrace(env testEnvironment, t *testing.T, callback func([]actuators.Actua
 	// now replay rest of the trace.
 	for i := 1; i < len(events); i++ {
 		fmt.Println(strconv.Itoa(i) + "----")
+		fmt.Printf("Event desired objectives: %v\n", events[i].Desired)
+		fmt.Printf("Event current objectives: %v\n", events[i].Current)
 		f.setCurrentObjectives(events[i].Current)
 		f.setCurrentData(events[i].Data)
 		f.setWorkloadState(events[i].Pods, events[i].Resources, events[i].Annotations)
+		time.Sleep(100 * time.Millisecond)
 		f.setDesiredObjectives(events[i].Intent, events[i].Desired)
 		f.tracer.stepIndex(i)
 
 		planEvent := <-f.ticker
 		if !comparePlans(events[i].Plan, planEvent.plan) {
 			t.Errorf("Expected %v - got %v.", events[i].Plan, planEvent.plan)
+			fmt.Println(strconv.Itoa(i) + "---- FAIL")
+		} else {
+			fmt.Println(strconv.Itoa(i) + "---- PASS")
 		}
 	}
 
@@ -738,7 +840,10 @@ func TestTracesForSanity(t *testing.T) {
 	rdtConfig, err5 := common.LoadConfig("traces/rdt.json", func() interface{} {
 		return &platform.RdtConfig{}
 	})
-	if err1 != nil || err2 != nil || err3 != nil || err4 != nil || err5 != nil {
+	cpuProfileConfig, err6 := common.LoadConfig("traces/cpu_profile.json", func() interface{} {
+		return &profiling.CPUProfileConfig{}
+	})
+	if err1 != nil || err2 != nil || err3 != nil || err4 != nil || err5 != nil || err6 != nil {
 		t.Errorf("Could not load config files!")
 	}
 
@@ -754,6 +859,9 @@ func TestTracesForSanity(t *testing.T) {
 		{name: "rdt_trace", effectsFilename: "traces/trace_rdt/effects.json", eventsFilename: "traces/trace_rdt/events.json", defaults: defaultsConfig.(*common.Config), actuators: map[string]actuatorSetup{
 			"NewCPUScaleActuator": {scaling.NewCPUScaleActuator, *cpuScaleConfig.(*scaling.CPUScaleConfig)},
 			"NewRDTActuator":      {platform.NewRdtActuator, *rdtConfig.(*platform.RdtConfig)}},
+		},
+		{name: "cpu_profiling_synth", effectsFilename: "traces/trace_profileCPU_synth/effects.json", eventsFilename: "traces/trace_profileCPU_synth/events.json", defaults: defaultsConfig.(*common.Config), actuators: map[string]actuatorSetup{
+			"NewCPUProfileActuator": {profiling.NewCPUProfileActuator, *cpuProfileConfig.(*profiling.CPUProfileConfig)}},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/tests/traces/cpu_profile.json
+++ b/pkg/tests/traces/cpu_profile.json
@@ -1,0 +1,45 @@
+{
+  "interpreter": "echo",
+  "analytics_script": "",
+  "prediction_script": "../../planner/actuators/profiling/test_predict.py",
+  "cpu_max": 4000,
+  "cpu_profiles": [
+    {
+      "id": 1,
+      "name": "standard",
+      "cpu_manager": 0,
+      "affinity": 0,
+      "settings": {}
+    },
+    {
+      "id": 2,
+      "name": "exclusive",
+      "cpu_manager": 0,
+      "affinity": 0,
+      "settings": {"cpu_manager_policy": "static"}
+    },
+    {
+      "id": 3,
+      "name": "pexclusive",
+      "cpu_manager": 0,
+      "affinity": 0,
+      "settings": 
+      {
+        "cpu_manager_policy": "static",
+        "full_pcpu_only": "true"
+      }
+    },
+    {
+      "id": 4,
+      "name": "topology-aware",
+      "cpu_manager": 0,
+      "affinity": 0,
+      "settings": {
+        "cpu_manager_policy": "static",
+        "topology_manager_policy": "besteffort",
+        "topology-manager-scope": "pod"
+      }
+    }
+  ]
+}
+

--- a/pkg/tests/traces/trace_profileCPU_synth/effects.json
+++ b/pkg/tests/traces/trace_profileCPU_synth/effects.json
@@ -1,0 +1,134 @@
+[
+{
+  "_id": {
+    "$oid": "65b7a9d6c34376a54780332c"
+  },
+  "name": "default/my-intent",
+  "profileName": "default/p50latency",
+  "group": "profiling",
+  "data": {
+    "lookupTable": {
+      "1000": [
+          {"ID": 1, "latency": 150},
+          {"ID": 2, "latency": 120},
+          {"ID": 3, "latency": 100},
+          {"ID": 4, "latency": 95}
+      ],
+      "2000": [
+          {"ID": 1, "latency": 130},
+          {"ID": 2, "latency": 105},
+          {"ID": 3, "latency": 90},
+          {"ID": 4, "latency": 85}
+      ],
+      "3000": [
+          {"ID": 1, "latency": 90},
+          {"ID": 2, "latency": 75},
+          {"ID": 3, "latency": 70},
+          {"ID": 4, "latency": 55}
+      ],
+      "4000": [
+          {"ID": 1, "latency": 70},
+          {"ID": 2, "latency": 65},
+          {"ID": 3, "latency": 50},
+          {"ID": 4, "latency": 35}
+      ]
+    },
+    "trainingFeatures": [
+      "cpus",
+      "cpu_profile"
+    ],
+    "targetFeature": "default/p50latency"
+  },
+  "timestamp": {
+    "$date": "2024-01-29T14:36:22.920Z"
+  },
+  "static": true
+},{
+  "_id": {
+    "$oid": "65b7a9d4b9bd0848eca85768"
+  },
+  "name": "default/my-intent",
+  "profileName": "default/p95latency",
+  "group": "profiling",
+  "data": {
+    "lookupTable": {
+      "1000": [
+          {"ID": 1, "latency": 250},
+          {"ID": 2, "latency": 200},
+          {"ID": 3, "latency": 180},
+          {"ID": 4, "latency": 150}
+      ],
+      "2000": [
+          {"ID": 1, "latency": 230},
+          {"ID": 2, "latency": 190},
+          {"ID": 3, "latency": 150},
+          {"ID": 4, "latency": 120}
+      ],
+      "3000": [
+          {"ID": 1, "latency": 190},
+          {"ID": 2, "latency": 120},
+          {"ID": 3, "latency": 89},
+          {"ID": 4, "latency": 54}
+      ],
+      "4000": [
+          {"ID": 1, "latency": 150},
+          {"ID": 2, "latency": 95},
+          {"ID": 3, "latency": 70},
+          {"ID": 4, "latency": 39}
+      ]
+    },
+    "trainingFeatures": [
+      "cpus",
+      "cpu_profile"
+    ],
+    "targetFeature": "default/p95latency"},
+  "timestamp": {
+    "$date": "2024-01-29T14:36:20.311Z"
+  },
+  "static": true
+},{
+  "_id": {
+    "$oid": "65b7a9d14895657c322f7e6c"
+  },
+  "name": "default/my-intent",
+  "profileName": "default/p99latency",
+  "group": "profiling",
+  "data": {
+    "lookupTable": {
+      "1000": [
+          {"ID": 1, "latency": 290},
+          {"ID": 2, "latency": 200},
+          {"ID": 3, "latency": 180},
+          {"ID": 4, "latency": 150}
+      ],
+      "2000": [
+          {"ID": 1, "latency": 230},
+          {"ID": 2, "latency": 190},
+          {"ID": 3, "latency": 120},
+          {"ID": 4, "latency": 90}
+      ],
+      "3000": [
+          {"ID": 1, "latency": 190},
+          {"ID": 2, "latency": 120},
+          {"ID": 3, "latency": 89},
+          {"ID": 4, "latency": 54}
+      ],
+      "4000": [
+          {"ID": 1, "latency": 150},
+          {"ID": 2, "latency": 95},
+          {"ID": 3, "latency": 70},
+          {"ID": 4, "latency": 46}
+      ]
+    },
+    "trainingFeatures": [
+      "cpus",
+      "cpu_profile"
+    ],
+    "targetFeature": "default/p99latency"
+  },
+  "timestamp": {
+    "$date": "2024-01-29T14:36:17.619Z"
+  },
+  "static": true
+}]
+

--- a/pkg/tests/traces/trace_profileCPU_synth/events.json
+++ b/pkg/tests/traces/trace_profileCPU_synth/events.json
@@ -1,0 +1,655 @@
+[
+  {
+    "name": "default/my-intent",
+    "timestamp": "0",
+    "current_objectives": {
+      "default/p99latency": -1.0,
+      "default/p95latency": -1.0,
+      "default/p50latency": -1.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 300.0,
+      "default/p95latency": 150.0,
+      "default/p50latency": 100
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "1"
+    },
+    "pods": {
+      "function-deployment-0": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Pending",
+        "qosclass": "Guaranteed"
+      }
+  },
+  "data": {},
+  "plan": null  
+  },{
+    "name": "default/my-intent",
+    "timestamp":  "0",
+    "current_objectives": {
+      "default/p99latency": 143.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 300.0
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {},
+    "pods": {
+      "function-deployment-1": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan": [
+      {
+        "name": "profileCPU",
+        "properties": {
+          "id": 1
+        }
+      }
+    ]
+  },{
+    "name": "default/my-intent",
+    "timestamp":  "0",
+    "current_objectives": {
+      "default/p99latency": 143.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 300.0
+    },
+    "resources": {
+      "0_cpu_limits": 1000,
+      "0_cpu_requests": 1000
+    },
+    "annotations": {
+      "cpu_profile": "shared"
+    },
+    "pods": {
+      "function-deployment-2": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan":  [
+      {
+        "name": "profileCPU",
+        "properties": {
+          "id": 1
+        }
+      }
+    ]
+  },{
+    "name": "default/my-intent",
+    "timestamp": "0",
+    "current_objectives": {
+      "default/p99latency": 143.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 300.0
+    },
+    "resources": {
+      "0_cpu_limits": 1000,
+      "0_cpu_requests": 1000
+    },
+    "annotations": {
+      "cpu_profile": "9"
+    },
+    "pods": {
+      "function-deployment-3": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan":  [
+      {
+        "name": "profileCPU",
+        "properties": {
+          "id": 1
+        }
+      }
+    ]
+  },{
+    "name": "default/my-intent",
+    "timestamp": "0",
+    "current_objectives": {
+      "default/p99latency": 143.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 300.0
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "-4"
+    },
+    "pods": {
+      "function-deployment-4": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan":  [
+      {
+        "name": "profileCPU",
+        "properties": {
+          "id": 1
+        }
+      }
+    ]
+  },{
+    "name": "default/my-intent",
+    "timestamp": "0",
+    "current_objectives": {
+      "default/p99latency": 143.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 300.0
+    },
+    "resources": {
+      "0_cpu_requests": -1,
+      "0_cpu_limits": 0
+    },
+    "annotations": {
+      "cpu_profile": "1"
+    },
+    "pods": {
+      "function-deployment-5": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan": null
+  },{
+    "name": "default/my-intent",
+    "timestamp": "0",
+    "current_objectives": {
+      "default/p99latency": 143.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 300.0
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "1"
+    },
+    "pods": {
+      "function-deployment-6": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Burstable"
+      }
+    },
+    "data": {},
+    "plan": null
+  },{
+    "name": "default/my-intent",
+    "timestamp": "0",
+    "current_objectives": {
+      "default/p99latency": 143.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 300.0
+    },
+    "resources": {
+      "0_cpu_requests": 300,
+      "0_cpu_limits": 300
+    },
+    "annotations": {
+      "cpu_profile": "4"
+    },
+    "pods": {
+      "function-deployment-7": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan": null
+  },{
+    "name": "default/my-intent",
+    "timestamp":  "0",
+    "current_objectives": {
+      "default/p99latency": 143.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 300.0
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "2"
+    },
+    "pods": {
+      "function-deployment-8": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan": [
+      {
+        "name": "profileCPU",
+        "properties": {
+          "id": 1
+        }
+      }
+    ]
+  },{
+    "name": "default/my-intent",
+    "timestamp": "0",
+    "current_objectives": {
+      "default/p99latency": 300.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 200.0
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "1"
+    },
+    "pods": {
+      "function-deployment-9": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan":  [
+      {
+        "name": "profileCPU",
+        "properties": {
+          "id": 2
+        }
+      }
+    ]
+  },{
+    "name": "default/my-intent",
+    "timestamp":  "0",
+    "current_objectives": {
+      "default/p99latency": 250.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 200.0
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "1"
+    },
+    "pods": {
+      "function-deployment-10": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan":  [
+      {
+        "name": "profileCPU",
+        "properties": {
+          "id": 2
+        }
+      }
+    ]
+  },{
+    "name": "default/my-intent",
+    "timestamp":  "0",
+    "current_objectives": {
+      "default/p99latency": 310.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 300.0
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "1"
+    },
+    "pods": {
+      "function-deployment-11": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan":   [
+      {
+        "name": "profileCPU",
+        "properties": {
+          "id": 1
+        }
+      }
+    ]
+  },{
+    "name": "default/my-intent",
+    "timestamp": "0",
+    "current_objectives": {
+      "default/p99latency": 310.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 300.0
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "2"
+    },
+    "pods": {
+      "function-deployment-12": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan":  [
+      {
+        "name": "profileCPU",
+        "properties": {
+          "id": 1
+        }
+      }
+    ]
+  },{
+    "name": "default/my-intent",
+    "timestamp": "0",
+    "current_objectives": {
+      "default/p99latency": 310.0
+    },
+    "desired_objectives": {
+      "default/p99latency": 100.0
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "1"
+    },
+    "pods": {
+      "function-deployment-13": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan": null
+  },{
+    "name": "default/my-intent",
+    "timestamp": "0",
+    "current_objectives": {
+      "default/p99latency": 250,
+      "default/p95latency": 200
+    },
+    "desired_objectives": {
+      "default/p99latency": 200.0,
+      "default/p95latency": 150.0
+    },
+    "resources": {
+      "0_cpu_requests": 2000,
+      "0_cpu_limits": 2000
+    },
+    "annotations": {
+      "cpu_profile": "1"
+    },
+    "pods": {
+      "function-deployment-14": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan":[
+      {
+        "name": "profileCPU",
+        "properties": {
+          "id": 3
+        }
+      }
+    ]
+  },{
+    "name": "default/my-intent",
+    "timestamp": "0",
+    "current_objectives": {
+      "default/p95latency": 250,
+      "default/p99latency": 200
+    },
+    "desired_objectives": {
+      "default/p95latency": 150.0,
+      "default/p99latency": 100.0
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "1"
+    },
+    "pods": {
+      "function-deployment-15": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan": null
+  },{
+    "name": "default/my-intent",
+    "timestamp":  "0",
+    "current_objectives": {
+      "default/p99latency": 250,
+      "default/p95latency": 200
+    },
+    "desired_objectives": {
+      "default/p99latency": 90.0,
+      "default/p95latency": 75.0
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "1"
+    },
+    "pods": {
+      "function-deployment-16": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan": null
+  },{
+    "name": "default/my-intent",
+    "timestamp":  "0",
+    "current_objectives": {
+      "default/p99latency": 69.5,
+      "default/p95latency": 70.2
+    },
+    "desired_objectives": {
+      "default/p95latency": 250.0,
+      "default/p99latency": 300.0
+    },
+    "resources": {
+      "0_cpu_limits": 1000,
+      "0_cpu_requests": 1000
+    },
+    "annotations": {
+      "cpu_profile": "3"
+    },
+    "pods": {
+      "function-deployment-17": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan": [
+      {
+        "name": "profileCPU",
+        "properties": {
+          "id": 1
+        }
+      }
+    ]
+  },{
+    "name": "default/my-intent",
+    "timestamp":  "0",
+    "current_objectives": {
+      "default/p99latency": 200,
+      "default/p95latency": 200,
+      "default/p50latency": 100
+    },
+    "desired_objectives": {
+      "default/p99latency": 150,
+      "default/p95latency": 150,
+      "default/p50latency": 95
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "2"
+    },
+    "pods": {
+      "function-deployment-18": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan": [
+      {
+        "name": "profileCPU",
+        "properties": {
+          "id": 4
+        }
+      }
+    ]
+  },{
+    "name": "default/my-intent",
+    "timestamp": "0",
+    "current_objectives": {
+      "default/p99latency": 198,
+      "default/p95latency": 180,
+      "default/p50latency": 186
+    },
+    "desired_objectives": {
+      "default/p99latency": 85,
+      "default/p95latency": 80,
+      "default/p50latency": 75
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "2"
+    },
+    "pods": {
+      "function-deployment-19": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan": null
+  },{
+    "name": "default/my-intent",
+    "timestamp":  "0",
+    "current_objectives": {
+      "default/p99latency": 198.94,
+      "default/p95latency": 180,
+      "default/p50latency": 186
+    },
+    "desired_objectives": {
+      "default/p99latency": 85.0,
+      "default/p95latency": 80,
+      "default/p50latency": 75
+    },
+    "resources": {
+      "0_cpu_requests": 1000,
+      "0_cpu_limits": 1000
+    },
+    "annotations": {
+      "cpu_profile": "4"
+    },
+    "pods": {
+      "function-deployment-20": {
+        "availability": 1.0,
+        "nodename": "",
+        "state": "Running",
+        "qosclass": "Guaranteed"
+      }
+    },
+    "data": {},
+    "plan": null
+  }
+]

--- a/plugins/cpu_profile/Dockerfile
+++ b/plugins/cpu_profile/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright (c) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+FROM golang:1.22 AS builder
+
+WORKDIR /plugins
+
+COPY . ./
+
+RUN make prepare-build build-plugins \
+    && go run github.com/google/go-licenses@v1.6.0 save "./..." --save_path licenses \
+    && hack/additional-licenses.sh
+
+FROM alpine:3.20
+
+RUN adduser -D nonroot
+RUN apk add --upgrade --no-cache openssl=~3.3 && apk add --no-cache python3=~3.12 py3-matplotlib=~3.7 \
+    py3-pip=~24.0 py3-scikit-learn=~1.3
+RUN pip install --break-system-packages --no-cache-dir pymongo~=4.6
+
+WORKDIR /plugins
+
+COPY --from=builder /plugins/bin/plugins/cpu_profile /plugins/bin/plugins/cpu_profile
+COPY --from=builder /plugins/licenses ./licenses
+COPY pkg/planner/actuators/profiling/analytics/analyze.py /plugins/pkg/planner/actuators/profiling/analyze.py
+COPY pkg/planner/actuators/profiling/analytics/predict.py /plugins/pkg/planner/actuators/profiling/predict.py
+USER nonroot:nonroot
+EXPOSE 33334
+
+ENTRYPOINT ["/plugins/bin/plugins/cpu_profile"]
+

--- a/plugins/cpu_profile/cmd/cpu_profile.go
+++ b/plugins/cpu_profile/cmd/cpu_profile.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/intel/intent-driven-orchestration/pkg/controller"
+
+	pluginsHelper "github.com/intel/intent-driven-orchestration/plugins"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/intel/intent-driven-orchestration/pkg/common"
+	"github.com/intel/intent-driven-orchestration/pkg/planner/actuators/profiling"
+
+	"k8s.io/klog/v2"
+)
+
+// maxLookBack defines the maximum age a model in the knowledge base can have (1 week)
+const maxLookBack = 10080
+
+var (
+	kubeConfig string
+	config     string
+)
+
+func init() {
+	flag.StringVar(&kubeConfig, "kubeConfig", "", "Path to a kube config file.")
+	flag.StringVar(&config, "config", "", "Path to configuration file.")
+}
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	tmp, err := common.LoadConfig(config, func() interface{} {
+		return &profiling.CPUProfileConfig{}
+	})
+	if err != nil {
+		klog.Fatalf("Error loading configuration for actuator: %s", err)
+	}
+	cfg := tmp.(*profiling.CPUProfileConfig)
+
+	// validate configuration.
+	err = pluginsHelper.IsValidGenericConf(cfg.Endpoint, cfg.Port, cfg.PluginManagerEndpoint, cfg.PluginManagerPort, cfg.MongoEndpoint)
+	if err != nil {
+		klog.Fatalf("Error on generic configuration for actuator: %s", err)
+	}
+
+	err = isValidConf(cfg.Interpreter, cfg.Analytics, cfg.Prediction, cfg.CPUMax, cfg.CPUProfiles, cfg.LookBack)
+	if err != nil {
+		klog.Fatalf("Error on configuration for actuator: %s", err)
+	}
+
+	// get K8s config.
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfig)
+	if err != nil {
+		klog.Fatalf("Error getting Kubernetes config: %s", err)
+	}
+	clusterClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		klog.Fatalf("Error creating Kubernetes cluster client: %s", err)
+	}
+
+	// once configuration is ready & valid start the plugin mechanism.
+	mt := controller.NewMongoTracer(cfg.MongoEndpoint)
+	actuator := profiling.NewCPUProfileActuator(clusterClient, mt, *cfg)
+	signal := pluginsHelper.StartActuatorPlugin(actuator, cfg.Endpoint, cfg.Port, cfg.PluginManagerEndpoint, cfg.PluginManagerPort)
+	<-signal
+}
+
+// TODO: add checking on cpuMax
+func isValidConf(interpreter, analyzeScript string, predictionScript string, cpuMax int64, CPUProfiles []profiling.CPUProfile, lookBack int) error {
+	if !pluginsHelper.IsStrConfigValid(interpreter) {
+		return fmt.Errorf("invalid path to python interpreter: %s", interpreter)
+	}
+
+	if analyzeScript != "None" {
+		_, err := os.Stat(analyzeScript)
+		if err != nil {
+			return fmt.Errorf("invalid script %s", err)
+		}
+	}
+
+	if predictionScript != "None" {
+		_, err := os.Stat(predictionScript)
+		if err != nil {
+			return fmt.Errorf("invalid script %s", err)
+		}
+	}
+
+	if err := isValidCPUProfiles(CPUProfiles); err != nil {
+		return fmt.Errorf("invalid cpu profiles: %s", err)
+	}
+
+	if lookBack <= 0 || lookBack > maxLookBack {
+		return fmt.Errorf("invalid lookback value: %d", lookBack)
+	}
+
+	return nil
+}
+
+func isValidCPUProfiles(CPUProfiles []profiling.CPUProfile) error {
+	if len(CPUProfiles) == 0 {
+		return errors.New("cpuProfiles slice is empty")
+	}
+
+	ids := make(map[int]bool)
+
+	for _, profile := range CPUProfiles {
+		// Check ID
+		if profile.ID <= 0 {
+			return fmt.Errorf("invalid ID %d in profile %s", profile.ID, profile.Name)
+		}
+		if ids[profile.ID] {
+			return fmt.Errorf("duplicate ID %d found in profiles", profile.ID)
+		}
+		ids[profile.ID] = true
+
+		// Check Name
+		if !isValidString(profile.Name) {
+			return fmt.Errorf("profile with ID %d has invalid name", profile.ID)
+		}
+
+		// Check CPUManager
+		if profile.CPUManager != profiling.Vanilla && profile.CPUManager != profiling.CPUControlPlane {
+			return fmt.Errorf("invalid CPUManager in profile %s", profile.Name)
+		}
+
+		// Check Affinity
+		if profile.Affinity != profiling.Preferred && profile.Affinity != profiling.Required {
+			return fmt.Errorf("invalid Affinity in profile %s", profile.Name)
+		}
+
+		// Check Settings
+		for key, value := range profile.Settings {
+			if !isValidString(key) {
+				return fmt.Errorf("empty key in settings for profile %s", profile.Name)
+			}
+			if !isValidString(value) {
+				return fmt.Errorf("empty value for key '%s' in settings for profile %s", key, profile.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+func isValidString(text string) bool {
+	if text == "" {
+		return false
+	}
+
+	if len(text) == 1 {
+		return regexp.MustCompile(`^[a-zA-Z0-9]$`).MatchString(text)
+	}
+
+	return regexp.MustCompile(`^[a-zA-Z0-9][a-z0-9._-]*[a-zA-Z0-9]$`).MatchString(text)
+}

--- a/plugins/cpu_profile/cmd/cpu_profile_test.go
+++ b/plugins/cpu_profile/cmd/cpu_profile_test.go
@@ -1,0 +1,382 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/intel/intent-driven-orchestration/pkg/planner/actuators/profiling"
+)
+
+// pathToAnalyticsScript defines the path to an existing script for this actuator.
+const pathToAnalyticsScript = "../../../pkg/planner/actuators/profiling/test_analyze.py"
+const pathToPredictScript = "../../../pkg/planner/actuators/profiling/test_predict.py"
+
+func TestIsValidConf(t *testing.T) {
+	type args struct {
+		interpreter      string
+		analyticsScript  string
+		predictionScript string
+		cpuMax           int64
+		cpuProfiles      []profiling.CPUProfile
+		lookBack         int
+	}
+	validCPUProfiles := []profiling.CPUProfile{
+		{
+			ID:         1,
+			Name:       "standard",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings:   map[string]string{},
+		},
+		{
+			ID:         2,
+			Name:       "exclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+			},
+		},
+		{
+			ID:         3,
+			Name:       "pexclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+				"full_pcpu_only":     "true",
+			},
+		},
+		{
+			ID:         4,
+			Name:       "topology-aware",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy":      "static",
+				"topology_manager_policy": "besteffort",
+				"topology-manager-scope":  "pod",
+			},
+		},
+	}
+
+	duplicateIdCPUProfiles := []profiling.CPUProfile{
+		{
+			ID:         1, //duplicated
+			Name:       "standard",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings:   map[string]string{},
+		},
+		{
+			ID:         2,
+			Name:       "exclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+			},
+		},
+		{
+			ID:         1, //duplicate
+			Name:       "pexclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+				"full_pcpu_only":     "true",
+			},
+		},
+	}
+
+	negativeIdCPUProfiles := []profiling.CPUProfile{
+		{
+			ID:         -1, //incorrect
+			Name:       "standard",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings:   map[string]string{},
+		},
+		{
+			ID:         2,
+			Name:       "exclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+			},
+		},
+		{
+			ID:         3,
+			Name:       "pexclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+				"full_pcpu_only":     "true",
+			},
+		},
+	}
+
+	zeroIdCPUProfiles := []profiling.CPUProfile{
+		{
+			ID:         0, //incorrect
+			Name:       "standard",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings:   map[string]string{},
+		},
+		{
+			ID:         2,
+			Name:       "exclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+			},
+		},
+		{
+			ID:         3,
+			Name:       "pexclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+				"full_pcpu_only":     "true",
+			},
+		},
+	}
+
+	emptyCPUProfiles := []profiling.CPUProfile{}
+
+	invalidNameCPUProfiles := []profiling.CPUProfile{
+		{
+			ID:         1,
+			Name:       "", //incorrect
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings:   map[string]string{},
+		},
+		{
+			ID:         2,
+			Name:       "exclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+			},
+		},
+		{
+			ID:         3,
+			Name:       "pexclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+				"full_pcpu_only":     "true",
+			},
+		},
+	}
+
+	invalidManagerCPUProfiles := []profiling.CPUProfile{
+		{
+			ID:         1,
+			Name:       "standard",
+			CPUManager: 3, //incorrect
+			Affinity:   profiling.Preferred,
+			Settings:   map[string]string{},
+		},
+		{
+			ID:         2,
+			Name:       "exclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+			},
+		},
+		{
+			ID:         3,
+			Name:       "pexclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+				"full_pcpu_only":     "true",
+			},
+		},
+	}
+
+	invalidAffinityCPUProfiles := []profiling.CPUProfile{
+		{
+			ID:         1,
+			Name:       "standard",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings:   map[string]string{},
+		},
+		{
+			ID:         2,
+			Name:       "exclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   3, // incorrect
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+			},
+		},
+		{
+			ID:         3,
+			Name:       "pexclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+				"full_pcpu_only":     "true",
+			},
+		},
+	}
+
+	invalidSettingsKeyCPUProfiles := []profiling.CPUProfile{
+		{
+			ID:         1,
+			Name:       "standard",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings:   map[string]string{},
+		},
+		{
+			ID:         2,
+			Name:       "exclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"_cpu_manager_policy": "static", //incorrect
+			},
+		},
+		{
+			ID:         3,
+			Name:       "pexclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+				"full_pcpu_only":     "true",
+			},
+		},
+	}
+
+	invalidSettingsValueCPUProfiles := []profiling.CPUProfile{
+		{
+			ID:         1,
+			Name:       "standard",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings:   map[string]string{},
+		},
+		{
+			ID:         2,
+			Name:       "exclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static-", //incorrect
+			},
+		},
+		{
+			ID:         3,
+			Name:       "pexclusive",
+			CPUManager: profiling.Vanilla,
+			Affinity:   profiling.Preferred,
+			Settings: map[string]string{
+				"cpu_manager_policy": "static",
+				"full_pcpu_only":     "true",
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "tc-0",
+			args:    args{"python3", pathToAnalyticsScript, pathToPredictScript, 4000, validCPUProfiles, 10000},
+			wantErr: false,
+		},
+		{
+			name:    "tc-1",
+			args:    args{"", pathToAnalyticsScript, pathToPredictScript, 4000, validCPUProfiles, 10000},
+			wantErr: true,
+		},
+		{
+			name:    "tc-2",
+			args:    args{"python3", "", pathToPredictScript, 4000, validCPUProfiles, 10000},
+			wantErr: true,
+		},
+		{
+			name:    "tc-3",
+			args:    args{"python3", pathToAnalyticsScript, pathToPredictScript, 4000, duplicateIdCPUProfiles, 10000},
+			wantErr: true, // duplicate ID
+		},
+		{
+			name:    "tc-4",
+			args:    args{"python3", pathToAnalyticsScript, pathToPredictScript, 4000, negativeIdCPUProfiles, 10000},
+			wantErr: true, //negative ID
+		},
+		{
+			name:    "tc-5",
+			args:    args{"python3", pathToAnalyticsScript, pathToPredictScript, 4000, zeroIdCPUProfiles, 10000},
+			wantErr: true, //zero ID
+		},
+		{
+			name:    "tc-6",
+			args:    args{"python3", pathToAnalyticsScript, pathToPredictScript, 4000, emptyCPUProfiles, 10000},
+			wantErr: true, //empty CPUProfiles slice
+		},
+		{
+			name:    "tc-7",
+			args:    args{"python3", pathToAnalyticsScript, pathToPredictScript, 4000, invalidNameCPUProfiles, 10000},
+			wantErr: true, //invalid Name
+		},
+		{
+			name:    "tc-8",
+			args:    args{"python3", pathToAnalyticsScript, pathToPredictScript, 4000, invalidManagerCPUProfiles, 10000},
+			wantErr: true, //invalid CPUManager
+		},
+		{
+			name:    "tc-9",
+			args:    args{"python3", pathToAnalyticsScript, pathToPredictScript, 4000, invalidAffinityCPUProfiles, 10000},
+			wantErr: true, //invalid affinity
+		},
+		{
+			name:    "tc-10",
+			args:    args{"python3", pathToAnalyticsScript, pathToPredictScript, 4000, invalidSettingsKeyCPUProfiles, 10000},
+			wantErr: true, //invalid settings key
+		},
+		{
+			name:    "tc-11",
+			args:    args{"python3", pathToAnalyticsScript, pathToPredictScript, 4000, invalidSettingsValueCPUProfiles, 10000},
+			wantErr: true, //invalid settings value
+		},
+		{
+			name:    "tc-12",
+			args:    args{"python3", pathToAnalyticsScript, pathToPredictScript, 4000, validCPUProfiles, -1},
+			wantErr: true, // negative lookback.
+		},
+		{
+			name:    "tc-13",
+			args:    args{"python3", pathToAnalyticsScript, pathToPredictScript, 4000, validCPUProfiles, 999999},
+			wantErr: true, // over limit lookback.
+		},
+	}
+	for _, tt := range tests {
+		fmt.Printf("test: %v\n", tt.name)
+		t.Run(tt.name, func(t *testing.T) {
+			if err := isValidConf(tt.args.interpreter, tt.args.analyticsScript, tt.args.predictionScript, tt.args.cpuMax,
+				tt.args.cpuProfiles, tt.args.lookBack); (err != nil) != tt.wantErr {
+				t.Errorf("isValidConf() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/plugins/cpu_profile/cpu-profile-actuator-plugin.yaml
+++ b/plugins/cpu_profile/cpu-profile-actuator-plugin.yaml
@@ -1,0 +1,131 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cpu-profile-configmap
+data:
+  defaults.json: |-
+    {
+      "interpreter": "python3",
+      "analytics_script": "./pkg/planner/actuators/profiling/analyze.py",
+      "prediction_script": "./pkg/planner/actuators/profiling/predict.py",
+      "cpu_max": 20000,
+      "look_back": 20,
+      "endpoint": "cpu-profile-actuator-service",
+      "port": 33334,
+      "mongo_endpoint": "mongodb://planner-mongodb-service:27017/",
+      "telemetry_endpoint": "",
+      "plugin_manager_endpoint": "plugin-manager-service",
+      "plugin_manager_port": 33333,
+      "cpu_profiles": [
+        {
+          "id": 1,
+          "name": "default",
+          "cpu_manager": 0,
+          "affinity": 1,
+          "settings": {}
+        },
+        {
+          "id": 2,
+          "name": "exclusive",
+          "cpu_manager": 0,
+          "affinity": 1,
+          "settings":
+            {"cpu_manager_policy": "static"}
+        },
+        {
+          "id": 3,
+          "name": "numa_exclusive",
+          "cpu_manager": 0,
+          "affinity": 1,
+          "settings":
+            {"topology_policy": "single-numa-node"}
+        },
+        {
+          "id": 4,
+          "name": "pexclusive",
+          "cpu_manager": 0,
+          "affinity": 1,
+          "settings":
+            {"full_pcpu_only": "true"}
+        }
+      ]
+    }
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cpu-profile-actuator
+  labels:
+    name: cpu-profile-actuator
+spec:
+  serviceAccountName: planner-service-account
+  containers:
+    - name: cpu-profile-actuator
+      image: 127.0.0.1:5000/cpu-profiling:0.0.1 
+      imagePullPolicy: Always
+      args: [ "-config", "/config/defaults.json", "-v", "2" ]
+      ports:
+        - containerPort: 33334
+      securityContext:
+        capabilities:
+          drop: [ 'ALL' ]
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+      resources:
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+        requests:
+          memory: "512Mi"
+          cpu: "500m"
+      volumeMounts:
+        - name: cpu-profile-configmap-volume
+          mountPath: /config/
+        - name: matplotlib-tmp
+          mountPath: /var/tmp
+      env:
+        # Needed for the analytics python script.
+        - name: MONGO_URL
+          value: "mongodb://planner-mongodb-service:27017/"
+        - name: MPLCONFIGDIR
+          value: /var/tmp
+  volumes:
+    - name: matplotlib-tmp
+      emptyDir:
+        sizeLimit: 100Mi
+    - name: cpu-profile-configmap-volume
+      configMap:
+        name: cpu-profile-configmap
+        items:
+          - key: defaults.json
+            path: defaults.json
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cpu-profile-actuator-service
+spec:
+  clusterIP: None
+  selector:
+    name: cpu-profile-actuator
+  ports:
+    - protocol: TCP
+      port: 33334
+      targetPort: 33334


### PR DESCRIPTION
This PR adds a new CPU profiling actuator. It allows the planner to allocate workloads to specific nodes based on CPU profiles (e.g., exclusive cores, NUMA affinity) using Kubernetes node labels and pod affinity rules.

Changes:

Added pkg/planner/actuators/profiling for core logic.

Added plugins/cpu_profile for the actuator plugin.

Updated Makefile for building the new plugin.

Included documentation and example manifests.